### PR TITLE
Update pdo/ez_sql_pdo.php

### DIFF
--- a/pdo/ez_sql_pdo.php
+++ b/pdo/ez_sql_pdo.php
@@ -3,6 +3,7 @@
 /**********************************************************************
 *  Author: Justin Vincent (jv@jvmultimedia.com)
 *  Web...: http://twitter.com/justinvincent
+*  Update: Isuru Sampath Ratnayake @isuru_ra
 *  Name..: ezSQL_pdo
 *  Desc..: SQLite component (part of ezSQL databse abstraction library)
 *
@@ -44,6 +45,10 @@ class ezSQL_pdo extends ezSQLcore
 
 		if ( $dsn && $user && $password )
 		{
+			$this->dsn = $dsn; 
+			$this->user = $user;
+			$this->password = $password;
+			$this->ssl = $ssl;
 			$this->connect($dsn, $user, $password,$ssl);
 		}
 	}


### PR DESCRIPTION
Hi Justin,

Thanks! for this useful php mysql class.I did few code modifications to support pdo ssl for mysql databases. after this change it will work on xeround.com cloud database ssl mode without a problem. I decided to share code with you

Changes.
1. add $ssl = array() into constructor, connect, quick_connect and select 
2. add fllowing code to line 69
            if(!empty($ssl))
            {
                $this->dbh = new PDO($dsn, $user, $password,$ssl);
            }
            else{
                $this->dbh = new PDO($dsn, $user, $password);
            }
1. bug fixes add stdClass() object in line 256,269 to fix warning
2. bug fixes add empty check for native_type in line 258
# How do you use the code

$db_ssl = array(PDO::MYSQL_ATTR_SSL_KEY    =>'/path/to/client-key.pem',PDO::MYSQL_ATTR_SSL_CERT=>'/path/to/client-cert.pem',PDO::MYSQL_ATTR_SSL_CA    =>'/path/to/ca-cert.pem');

$db = new ezSQL_pdo($dsn,$db_username,$db_password,$db_ssl);

Thanks!
Best Regards,
Isuru Ratnayake
