### PR TITLE
Add optional encoding parameter to the current database connection, default to UTF-8

### DIFF
--- a/mysql/ez_sql_mysql.php
+++ b/mysql/ez_sql_mysql.php
@@ -35,18 +35,20 @@
 		var $dbpassword = false;
 		var $dbname = false;
 		var $dbhost = false;
+		var $encoding = false;
 
 		/**********************************************************************
 		*  Constructor - allow the user to perform a qucik connect at the
 		*  same time as initialising the ezSQL_mysql class
 		*/
 
-		function ezSQL_mysql($dbuser='', $dbpassword='', $dbname='', $dbhost='localhost')
+		function ezSQL_mysql($dbuser='', $dbpassword='', $dbname='', $dbhost='localhost', $encoding='utf8')
 		{
 			$this->dbuser = $dbuser;
 			$this->dbpassword = $dbpassword;
 			$this->dbname = $dbname;
 			$this->dbhost = $dbhost;
+			$this->encoding = $encoding;
 		}
 
 		/**********************************************************************
@@ -54,7 +56,7 @@
 		*  and select a mySQL database at the same time
 		*/
 
-		function quick_connect($dbuser='', $dbpassword='', $dbname='', $dbhost='localhost')
+		function quick_connect($dbuser='', $dbpassword='', $dbname='', $dbhost='localhost', $encoding='')
 		{
 			$return_val = false;
 			if ( ! $this->connect($dbuser, $dbpassword, $dbhost,true) ) ;
@@ -101,7 +103,7 @@
 		*  Try to select a mySQL database
 		*/
 
-		function select($dbname='',$encoding='utf8')
+		function select($dbname='', $encoding='')
 		{
 			global $ezsql_mysql_str; $return_val = false;
 
@@ -152,7 +154,7 @@
 			if ( ! isset($this->dbh) || ! $this->dbh )
 			{
 				$this->connect($this->dbuser, $this->dbpassword, $this->dbhost);
-				$this->select($this->dbname);
+				$this->select($this->dbname, $this->encoding);
 			}
 
 			return mysql_real_escape_string(stripslashes($str));
@@ -179,7 +181,7 @@
 			if ( $this->num_queries >= 500 )
 			{
 				$this->disconnect();
-				$this->quick_connect($this->dbuser,$this->dbpassword,$this->dbname,$this->dbhost);
+				$this->quick_connect($this->dbuser,$this->dbpassword,$this->dbname,$this->dbhost,$this->encoding);
 			}
 
 			// Initialise return
@@ -222,7 +224,7 @@
 			if ( ! isset($this->dbh) || ! $this->dbh )
 			{
 				$this->connect($this->dbuser, $this->dbpassword, $this->dbhost);
-				$this->select($this->dbname);
+				$this->select($this->dbname,$this->encoding);
 			}
 
 			// Perform the query via std mysql_query function..


### PR DESCRIPTION
Set optional encoding parameter for the current database connection, defaults to UTF-8. In fact UTF-8 encoded databases will not display values correctly in a php application if this is not set explicitly.
