### PR TITLE
Added intelligent check for valid CHARSET value against current mysql resource

### DIFF
--- a/mysql/ez_sql_mysql.php
+++ b/mysql/ez_sql_mysql.php
@@ -136,6 +136,7 @@
 				$this->dbname = $dbname;
 				if($encoding!='')
 				{
+					$encoding = strtolower(str_replace("-","",$encoding));
 					$charsets = array();
 					$result = mysql_query("SHOW CHARACTER SET");
 					while($row = mysql_fetch_array($result,MYSQL_ASSOC))


### PR DESCRIPTION
I have added a check against the current mysql recource for a valid CHARSET value. If the $encoding parameter contains a valid value, then the SET NAMES statement will be called. Otherwise the SET NAMES statement will simply be skipped over.

I figured it'd be nice to do an "intelligent" check. Since mysql refers to CHARSETS as lowercase and without dashes, this could lead to confusion if someone tries to set the $encoding parameter for example to "UTF-8". Since that would fail, we take care of that by automatically converting to lowercase and removing dashes. So "UTF-8" will automatically become "utf8".

Also I took out the default "utf8", perhaps it's more unobtrusive to not enforce an encoding. It will be completely up to the user to choose the encoding if required.
