### PR TITLE
Fix PHP Warning

### DIFF
--- a/codeigniter/Ezsql_codeigniter.php
+++ b/codeigniter/Ezsql_codeigniter.php
@@ -110,6 +110,8 @@
 							$i=0;
 							foreach ( get_object_vars($row) as $k => $v )
 							{
+								$this->col_info[$i] = new Stdclass();
+
 								$this->col_info[$i]->name = $k;
 								$this->col_info[$i]->max_length = $k;
 								$this->col_info[$i]->type = '';


### PR DESCRIPTION
Fix the below warning.

```
A PHP Error was encountered

Severity: Warning

Message: Creating default object from empty value

Filename: libraries/Ezsql_codeigniter.php

Line Number: 114
```
