### PR TITLE
Add 'set' query to query() method so no result object is fetched.

### DIFF
--- a/mysql/ez_sql_mysql.php
+++ b/mysql/ez_sql_mysql.php
@@ -254,7 +254,7 @@
 
 			// Query was an insert, delete, update, replace
 			$is_insert = false;
-			if ( preg_match("/^(insert|delete|update|replace|truncate|drop|create|alter)\s+/i",$query) )
+			if ( preg_match("/^(insert|delete|update|replace|truncate|drop|create|alter|set)\s+/i",$query) )
 			{
 				$this->rows_affected = @mysql_affected_rows($this->dbh);
 

--- a/mysqli/ez_sql_mysqli.php
+++ b/mysqli/ez_sql_mysqli.php
@@ -255,7 +255,7 @@
 			$is_insert = false;
 			
 			//if ( preg_match("/^(insert|delete|update|replace|truncate|drop|create|alter)\s+/i",$query) )
-			if ( preg_match("/^(insert|delete|update|replace|truncate|drop|create|alter|begin|commit|rollback)/i",$query) )
+			if ( preg_match("/^(insert|delete|update|replace|truncate|drop|create|alter|begin|commit|rollback|set)/i",$query) )
 			{
 				$this->rows_affected = @$this->dbh->affected_rows;
 


### PR DESCRIPTION
If you use a `SET` query, such as `SET NAMES utf8` and run it via `->query()` it kills the script. It's trying to fetch a result object that doesn't exist.

Have updated the `mysql` and `mysqli` extensions to include a check for `set` so that this doesn't happen.
