### PR TITLE
`get_results()` returns Empty Array if no result & `get_set()` tidy up

### DIFF
--- a/shared/ez_sql_core.php
+++ b/shared/ez_sql_core.php
@@ -240,7 +240,7 @@
 				}
 				else
 				{
-					return null;
+					return array();
 				}
 			}
 		}

--- a/shared/ez_sql_core_2.1_debughack_0.2alpha.php
+++ b/shared/ez_sql_core_2.1_debughack_0.2alpha.php
@@ -325,7 +325,7 @@
 				}
 				else
 				{
-					return null;
+					return array();
 				}
 			}
 		}

--- a/shared/ez_sql_core_202console.php
+++ b/shared/ez_sql_core_202console.php
@@ -291,7 +291,7 @@
 				}
 				else
 				{
-					return null;
+					return array();
 				}
 			}
 		}


### PR DESCRIPTION
Previously, a call to get_results() would return NULL if the output was ARRAY and no results were available. I have changed this to return an empty array (as this is the expected response type, is falsely, and prevents type errors when then output it used in a foreach loop.

Also modified get_set() function to pass through reserved SQL words without wrapping as strings ("NULL" != NULL, "NOW()" != NOW()).
