### PR TITLE
Misc PDO improvements

### DIFF
--- a/pdo/demo.php
+++ b/pdo/demo.php
@@ -1,9 +1,0 @@
-<?php
-
-	// Include ezSQL core
-	include_once "../shared/ez_sql_core.php";
-
-	// This is how to initialse ezsql for sqlite PDO
-	$db = new ezSQL_pdo('sqlite:my_database.sq3','someuser','somepassword');
-
-?>

--- a/pdo/demo_pdo_for_mysql.php
+++ b/pdo/demo_pdo_for_mysql.php
@@ -1,0 +1,42 @@
+<?php
+
+	// Include ezSQL core
+	include_once "../shared/ez_sql_core.php";
+
+	// Include ezSQL database specific component
+	include_once "ez_sql_pdo.php";
+
+	// Initialise database object and establish a connection at the same time
+	// db_user / db_password / db_name / db_host
+	// If you need to specify a custom port, use notation: 'mysql:host=127.0.0.1;port=9999;dbname=some_db'
+	$db = new ezSQL_pdo('mysql:host=db_host;dbname=db_name', 'db_user', 'db_password');
+
+	/**********************************************************************
+	*  ezSQL demo for mySQL database
+	*/
+
+	// Demo of getting a single variable from the db
+	// (and using abstracted function sysdate)
+	$current_time = $db->get_var("SELECT " . $db->sysdate());
+	print "ezSQL demo for mySQL database run @ $current_time";
+
+	// Print out last query and results..
+	$db->debug();
+
+	// Get list of tables from current database..
+	$my_tables = $db->get_results("SHOW TABLES",ARRAY_N);
+
+	// Print out last query and results..
+	$db->debug();
+
+	// Loop through each row of results..
+	foreach ( $my_tables as $table )
+	{
+		// Get results of DESC table..
+		$db->get_results("DESC $table[0]");
+
+		// Print out last query and results..
+		$db->debug();
+	}
+
+?>

--- a/pdo/demo_pdo_for_sqlite.php
+++ b/pdo/demo_pdo_for_sqlite.php
@@ -1,0 +1,12 @@
+<?php
+
+	// Include ezSQL core
+	include_once "../shared/ez_sql_core.php";
+	
+	// Include ezSQL database specific component
+	include_once "ez_sql_pdo.php";
+
+	// This is how to initialse ezsql for sqlite PDO
+	$db = new ezSQL_pdo('sqlite:my_database.sq3','someuser','somepassword');
+
+?>

--- a/pdo/ez_sql_pdo.php
+++ b/pdo/ez_sql_pdo.php
@@ -4,12 +4,12 @@
 	*  Author: Justin Vincent (jv@jvmultimedia.com)
 	*  Web...: http://twitter.com/justinvincent
 	*  Name..: ezSQL_pdo
-	*  Desc..: SQLite component (part of ezSQL databse abstraction library)
+	*  Desc..: PDO component (part of ezSQL databse abstraction library)
 	*
 	*/
 
 	/**********************************************************************
-	*  ezSQL error strings - SQLite
+	*  ezSQL error strings - PDO
 	*/
 
 	$ezsql_pdo_str = array
@@ -18,7 +18,7 @@
 	);
 
 	/**********************************************************************
-	*  ezSQL Database specific class - SQLite
+	*  ezSQL Database specific class - PDO
 	*/
 
 	if ( ! class_exists ('PDO') ) die('<b>Fatal Error:</b> ezSQL_pdo requires PDO Lib to be compiled and or linked in to the PHP engine');
@@ -34,7 +34,7 @@
 
 		/**********************************************************************
 		*  Constructor - allow the user to perform a qucik connect at the 
-		*  same time as initialising the ezSQL_sqlite class
+		*  same time as initialising the ezSQL_pdo class
 		*/
 
 		function ezSQL_pdo($dsn='', $user='', $password='', $ssl=array())
@@ -42,22 +42,22 @@
 			// Turn on track errors 
 			ini_set('track_errors',1);
 			
-			if ( $dsn && $user && $password )
+			if ( $dsn && $user )
 			{
 				$this->connect($dsn, $user, $password);
 			}
 		}
 
 		/**********************************************************************
-		*  Try to connect to SQLite database server
+		*  Try to connect to database server
 		*/
 
 		function connect($dsn='', $user='', $password='', $ssl=array())
 		{
 			global $ezsql_pdo_str; $return_val = false;
 			
-			// Must have a user and a password
-			if ( ! $dsn || ! $user || ! $password )
+			// Must have a dsn and user
+			if ( ! $dsn || ! $user )
 			{
 				$this->register_error($ezsql_pdo_str[1].' in '.__FILE__.' on line '.__LINE__);
 				$this->show_errors ? trigger_error($ezsql_pdo_str[1],E_USER_WARNING) : null;
@@ -87,7 +87,7 @@
 		}
 
 		/**********************************************************************
-		*  In the case of SQLite quick_connect is not really needed
+		*  In the case of PDO quick_connect is not really needed
 		*  because std. connect already does what quick connect does - 
 		*  but for the sake of consistency it has been included
 		*/
@@ -98,7 +98,7 @@
 		}
 
 		/**********************************************************************
-		*  No real equivalent of mySQL select in SQLite 
+		*  No real equivalent of mySQL select in PDO 
 		*  once again, function included for the sake of consistency
 		*/
 
@@ -108,7 +108,7 @@
 		}
 		
 		/**********************************************************************
-		*  Format a SQLite string correctly for safe SQLite insert
+		*  Format a string correctly for safe PDO insert
 		*  (no mater if magic quotes are on or not)
 		*/
 
@@ -128,13 +128,13 @@
 		}
 
 		/**********************************************************************
-		*  Return SQLite specific system date syntax 
+		*  Return specific system date syntax 
 		*  i.e. Oracle: SYSDATE Mysql: NOW()
 		*/
 
 		function sysdate()
 		{
-			return "datetime('now')";			
+			return "NOW()";			
 		}
 
 		/**********************************************************************


### PR DESCRIPTION
This PR brings a few misc improvements:
- the inline comments all mention SQLite, giving the false impression that this class is designed to interact with an SQLite DB only
- to make that clearer, I renamed the demo file to `demo_pdo_for_sqlite.php` and added an example file to interact with a MySQL server, named `demo_pdo_for_mysql.php`
- Also, the original example file for SQLite was broken: it was missing the inclusion of file `ez_sql_pdo.php` itself
- I fixed the `sysdate()` function to actually work on a MySQL server, which I thought is probably the widest use for this class
