### PR TITLE
Check for error on connect with mysqli

### DIFF
--- a/mysqli/ez_sql_mysqli.php
+++ b/mysqli/ez_sql_mysqli.php
@@ -90,18 +90,23 @@
 				$this->show_errors ? trigger_error($ezsql_mysqli_str[1],E_USER_WARNING) : null;
 			}
 			// Try to establish the server database handle
-			else if ( ! $this->dbh = new mysqli($dbhost,$dbuser,$dbpassword, '', $dbport) )
-			{
-				$this->register_error($ezsql_mysqli_str[2].' in '.__FILE__.' on line '.__LINE__);
-				$this->show_errors ? trigger_error($ezsql_mysqli_str[2],E_USER_WARNING) : null;
-			}
 			else
 			{
-				$this->dbuser = $dbuser;
-				$this->dbpassword = $dbpassword;
-				$this->dbhost = $dbhost;
-				$this->dbport = $dbport;
-				$return_val = true;
+				$this->dbh = new mysqli($dbhost,$dbuser,$dbpassword, '', $dbport);
+				// Check for connection problem
+				if( $this->dbh->connect_errno )
+				{
+					$this->register_error($ezsql_mysqli_str[2].' in '.__FILE__.' on line '.__LINE__);
+					$this->show_errors ? trigger_error($ezsql_mysqli_str[2],E_USER_WARNING) : null;
+				}
+				else
+				{
+					$this->dbuser = $dbuser;
+					$this->dbpassword = $dbpassword;
+					$this->dbhost = $dbhost;
+					$this->dbport = $dbport;
+					$return_val = true;
+				}
 			}
 
 			return $return_val;


### PR DESCRIPTION
The mysqli class performs an incorrect check on connection

`mysql_connect()` returns false when there's a connection error, but `mysqli_connect()` does not. To check for connection problems, you need to use function `mysqli_connect_errno()`
