### PR TITLE
Return false when no connection can be made

### DIFF
--- a/mysql/ez_sql_mysql.php
+++ b/mysql/ez_sql_mysql.php
@@ -241,6 +241,9 @@
 			{
 				$this->connect($this->dbuser, $this->dbpassword, $this->dbhost);
 				$this->select($this->dbname,$this->encoding);
+				// No existing connection at this point means the server is unreachable
+				if ( ! isset($this->dbh) || ! $this->dbh )
+					return false;
 			}
 
 			// Perform the query via std mysql_query function..

--- a/mysqli/ez_sql_mysqli.php
+++ b/mysqli/ez_sql_mysqli.php
@@ -251,6 +251,9 @@
 			{
 				$this->connect($this->dbuser, $this->dbpassword, $this->dbhost, $this->dbport);
 				$this->select($this->dbname,$this->encoding);
+				// No existing connection at this point means the server is unreachable
+				if ( ! isset($this->dbh) || ! $this->dbh->connect_errno )
+					return false;
 			}
 
 			// Perform the query via std mysql_query function..

--- a/pdo/ez_sql_pdo.php
+++ b/pdo/ez_sql_pdo.php
@@ -215,6 +215,9 @@
 			if ( ! isset($this->dbh) || ! $this->dbh )
 			{
 				$this->connect($this->dsn, $this->user, $this->password);
+				// No existing connection at this point means the server is unreachable
+				if ( ! isset($this->dbh) || ! $this->dbh )
+					return false;
 			}
 
 			// Query was an insert, delete, update, replace


### PR DESCRIPTION
Currently when an ezSQL class is instantiated, it doesn't open a connection to the server. This connection is created on the fly, if needed, when function `query()` is called, but no additional checks were made to make sure there was an actual connection.

As a result, various `mysql_` or PDO operation were performed and causing warning or fatal error (unoticed because of the `@` operator)

This PR makes the PDO, MySQL and MySQLi return false when a `->query()` is attempted against a server that is not responding.
