### PR TITLE
fix for Undefined property: stdClass::$max_length

### DIFF
--- a/shared/ez_sql_core.php
+++ b/shared/ez_sql_core.php
@@ -465,7 +465,15 @@
 
 				for ( $i=0; $i < count($this->col_info); $i++ )
 				{
-					echo "<td nowrap align=left valign=top><font size=1 color=555599 face=arial>{$this->col_info[$i]->type} {$this->col_info[$i]->max_length}</font><br><span style='font-family: arial; font-size: 10pt; font-weight: bold;'>{$this->col_info[$i]->name}</span></td>";
+					/* when selecting count(*) the maxlengh is not set, size is set instead. */
+					echo "<td nowrap align=left valign=top><font size=1 color=555599 face=arial>{$this->col_info[$i]->type}";
+					if (!isset($this->col_info[$i]->max_length))
+					{
+						echo "{$this->col_info[$i]->size}";
+					} else {
+						echo "{$this->col_info[$i]->max_length}";
+					}
+					echo "</font><br><span style='font-family: arial; font-size: 10pt; font-weight: bold;'>{$this->col_info[$i]->name}</span></td>";
 				}
 
 				echo "</tr>";


### PR DESCRIPTION
When performing a select count(*), on a table, the max_length is not defined, it is actually called size instead.

I've changed the output for debug() to check for the presence of the max_length property, and if it is not set, it will use the size property instead.  This block echoes out the proper value based on which is set.

previous error message : 
PHP Notice:  Undefined property: stdClass::$max_length in /lib/db/ez_sql_core.php on line 453
