### PR TITLE
Fixed PHP warning regarding creating default object from empty value (Oracle only)

### DIFF
--- a/oracle8_9/ez_sql_oracle8_9.php
+++ b/oracle8_9/ez_sql_oracle8_9.php
@@ -235,11 +235,11 @@
 					// Fetch the column meta data
 	    			for ( $i = 1; $i <= $num_cols; $i++ )
 	    			{					
-						# Check is_object to rid the following PHP 4.5+ error
-						# PHP Warning:  Creating default object from empty value in ez_sql_oracle8_9.php on line xxx
-						if ( !is_object($this->col_info) ) {
-							$this->col_info[] = new stdClass;
-						}
+					# Check is_object to rid the following PHP 4.5+ error
+					# PHP Warning:  Creating default object from empty value in ez_sql_oracle8_9.php on line xxx
+					if ( !is_object($this->col_info) ) {
+						$this->col_info[] = new stdClass;
+					}
 
 	    				$this->col_info[($i-1)]->name = @OCIColumnName($stmt,$i);
 	    				$this->col_info[($i-1)]->type = @OCIColumnType($stmt,$i);

--- a/oracle8_9/ez_sql_oracle8_9.php
+++ b/oracle8_9/ez_sql_oracle8_9.php
@@ -234,7 +234,13 @@
 				{
 					// Fetch the column meta data
 	    			for ( $i = 1; $i <= $num_cols; $i++ )
-	    			{
+	    			{					
+						# Check is_object to rid the following PHP 4.5+ error
+						# PHP Warning:  Creating default object from empty value in ez_sql_oracle8_9.php on line xxx
+						if ( !is_object($this->col_info) ) {
+							$this->col_info[] = new stdClass;
+						}
+
 	    				$this->col_info[($i-1)]->name = @OCIColumnName($stmt,$i);
 	    				$this->col_info[($i-1)]->type = @OCIColumnType($stmt,$i);
 	    				$this->col_info[($i-1)]->size = @OCIColumnSize($stmt,$i);
@@ -252,6 +258,12 @@
 						// then - loop through rows
 						foreach (  $col_contents as $col_content )
 						{
+							# Check is_object to rid the following PHP 4.5+ error
+							# PHP Warning:  Creating default object from empty value in ez_sql_oracle8_9.php on line xxx
+							if (!is_object($this->last_result)) {
+								$this->last_result[] = new stdClass;
+							}							
+
 							$this->last_result[$row_num]->{$col_title} = $col_content;
 							$row_num++;
 						}


### PR DESCRIPTION
With PHP 5.4 E_STRICT became part of E_ALL, so whereas pre 5.4 - you could specifically turn off E_STRICT it is now "on" by default.

While you can change 

~~~
 error_reporting = E_ALL
~~~
to 
~~~
error_reporting = E_ALL & ~E_NOTICE & ~E_STRICT
~~~

it is probably best to fix the issue, and that's what I've done.

This fix (for Oracle only) checks to see if the object exists before it starts assigning values to it.
I've inserted code to check 

~~~
$this->col_info
~~~

and

~~~
$this->last_result
~~~

If they are not objects, they are created as objects using the stdClass (generic empty class).
