### PR TITLE
Fix sqlsrv update query always returns false

### DIFF
--- a/sqlsrv/ez_sql_sqlsrv.php
+++ b/sqlsrv/ez_sql_sqlsrv.php
@@ -216,7 +216,7 @@
 			if ( preg_match("/^(insert|delete|update|replace)\s+/i",$query) )
 			{
 				$is_insert = true;
-				$this->rows_affected = @sqlsrv_rows_affected($this->dbh);
+				$this->rows_affected = @sqlsrv_rows_affected($this->result);
 
 				// Take note of the insert_id
 				if ( preg_match("/^(insert|replace)\s+/i",$query) )


### PR DESCRIPTION
Incorrect parameter being passed into @sqlsrv_rows_affected. 
Now correctly returns the affected rows. 

Reference: http://php.net/manual/en/function.sqlsrv-rows-affected.php