### PR TITLE
Improved queries counting

### DIFF
--- a/codeigniter/Ezsql_codeigniter.php
+++ b/codeigniter/Ezsql_codeigniter.php
@@ -42,7 +42,7 @@
 			$this->last_query = $query;
 			
 			// Count how many queries there have been
-			$this->num_queries++;
+			$this->count(true, true);
 			
 			// Start timer
 			$this->timer_start($this->num_queries);

--- a/cubrid/ez_sql_cubrid.php
+++ b/cubrid/ez_sql_cubrid.php
@@ -92,6 +92,8 @@
                 $this->dbname = $dbname;
                 $this->dbport = $dbport;
 				$return_val = true;
+
+				$this->conn_queries = 0;
 			}
 
 			return $return_val;
@@ -162,7 +164,7 @@
 			$this->last_query = $query;
 
 			// Count how many queries there have been
-			$this->num_queries++;
+			$this->count(true, true);
 			
 			// Start timer
 			$this->timer_start($this->num_queries);
@@ -270,7 +272,8 @@
 
 		function disconnect()
 		{
-			@cubrid_close($this->dbh);	
+			$this->conn_queries = 0;
+			@cubrid_close($this->dbh);
 		}
 
 	}

--- a/mssql/ez_sql_mssql.php
+++ b/mssql/ez_sql_mssql.php
@@ -99,6 +99,8 @@
 				$this->dbpassword = $dbpassword;
 				$this->dbhost = $dbhost;
 				$return_val = true;
+
+				$this->conn_queries = 0;
 			}
 
 			return $return_val;
@@ -200,7 +202,7 @@
 			$this->last_query = $query;
 
 			// Count how many queries there have been
-			$this->num_queries++;
+			$this->count(true, true);
 
 			// Use core file cache function
 			if ( $cache = $this->get_cache($query) )

--- a/mysql/ez_sql_mysql.php
+++ b/mysql/ez_sql_mysql.php
@@ -97,6 +97,8 @@
 				$this->dbpassword = $dbpassword;
 				$this->dbhost = $dbhost;
 				$return_val = true;
+
+				$this->conn_queries = 0;
 			}
 
 			return $return_val;
@@ -193,9 +195,8 @@
 		{
 
 			// This keeps the connection alive for very long running scripts
-			if ( $this->num_queries >= 500 )
+			if ( $this->count(false) >= 500 )
 			{
-				$this->num_queries = 0;
 				$this->disconnect();
 				$this->quick_connect($this->dbuser,$this->dbpassword,$this->dbname,$this->dbhost,$this->encoding);
 			}
@@ -216,7 +217,7 @@
 			$this->last_query = $query;
 
 			// Count how many queries there have been
-			$this->num_queries++;
+			$this->count(true, true);
 			
 			// Start timer
 			$this->timer_start($this->num_queries);
@@ -328,7 +329,8 @@
 
 		function disconnect()
 		{
-			@mysql_close($this->dbh);	
+			$this->conn_queries = 0; // Reset connection queries count
+			@mysql_close($this->dbh);
 		}
 
 	}

--- a/mysqli/ez_sql_mysqli.php
+++ b/mysqli/ez_sql_mysqli.php
@@ -108,6 +108,8 @@
 					$this->dbhost = $dbhost;
 					$this->dbport = $dbport;
 					$return_val = true;
+
+					$this->conn_queries = 0;
 				}
 			}
 
@@ -226,7 +228,7 @@
 			$this->last_query = $query;
 
 			// Count how many queries there have been
-			$this->num_queries++;
+			$this->count(true, true);
 			
 			// Start timer
 			$this->timer_start($this->num_queries);
@@ -338,6 +340,7 @@
 
 		function disconnect()
 		{
+			$this->conn_queries = 0;
 			@$this->dbh->close();
 		}
 

--- a/oracle8_9/ez_sql_oracle8_9.php
+++ b/oracle8_9/ez_sql_oracle8_9.php
@@ -78,6 +78,8 @@
 				$this->dbpassword = $dbpassword;
 				$this->dbname = $dbname;
 				$return_val = true;
+
+				$this->conn_queries = 0;
 			}
 
 			return $return_val;
@@ -184,7 +186,7 @@
 			// Keep track of the last query for debug..
 			$this->last_query = $query;
 
-			$this->num_queries++;
+			$this->count(true, true);
 
 			// Use core file cache function
 			if ( $cache = $this->get_cache($query) )

--- a/pdo/ez_sql_pdo.php
+++ b/pdo/ez_sql_pdo.php
@@ -76,7 +76,8 @@
 				{
 					$this->dbh = new PDO($dsn, $user, $password);
 				}
-				
+				$this->conn_queries = 0;
+
 				$return_val = true;
 			} 
 			catch (PDOException $e) 
@@ -190,7 +191,7 @@
 			// Keep track of the last query for debug..
 			$this->last_query = $query;
 
-			$this->num_queries++;
+			$this->count(true, true);
 
 			// Start timer
 			$this->timer_start($this->num_queries);

--- a/postgresql/ez_sql_postgresql.php
+++ b/postgresql/ez_sql_postgresql.php
@@ -97,6 +97,8 @@
 				$this->dbname = $dbname;
 				$this->port = $port;
 				$return_val = true;
+
+				$this->conn_queries = 0;
 			}
 
 			return $return_val;
@@ -178,7 +180,7 @@
 			$this->last_query = $query;
 
 			// Count how many queries there have been
-			$this->num_queries++;
+			$this->count(true, true);
 
 			// Use core file cache function
 			if ( $cache = $this->get_cache($query) )
@@ -283,7 +285,8 @@
 		{
 			if ( $this->dbh )
 			{
-			    @pg_close($this->dbh);
+			    $this->conn_queries = 0;
+				@pg_close($this->dbh);
 			}
 		}
 

--- a/shared/ez_sql_core.php
+++ b/shared/ez_sql_core.php
@@ -33,6 +33,7 @@
 		var $vardump_called   = false;
 		var $show_errors      = true;
 		var $num_queries      = 0;
+		var $conn_queries     = 0;
 		var $last_query       = null;
 		var $last_error       = null;
 		var $col_info         = null;
@@ -619,4 +620,19 @@
 			return implode( ', ' , $sql );
 		}
 
+		/**
+		 * Function for operating query count
+		 *
+		 * @param bool $all Set to false for function to return queries only during this connection
+		 * @param bool $increase Set to true to increase query count (internal usage)
+		 * @return int Returns query count base on $all
+		 */
+		function count ($all = true, $increase = false) {
+			if ($increase) {
+				$this->num_queries++;
+				$this->conn_queries++;
+			}
+
+			return ($all) ? $this->num_queries : $this->conn_queries;
+		}
 	}

--- a/sqlite/ez_sql_sqlite.php
+++ b/sqlite/ez_sql_sqlite.php
@@ -68,7 +68,10 @@
 				$this->show_errors ? trigger_error($php_errormsg,E_USER_WARNING) : null;
 			}
 			else
+			{
 				$return_val = true;
+				$this->conn_queries = 0;
+			}
 
 			return $return_val;			
 		}
@@ -141,7 +144,7 @@
 
 			// Perform the query via std mysql_query function..
 			$this->result = @sqlite_query($this->dbh,$query);
-			$this->num_queries++;
+			$this->count(true, true);
 
 			// If there is an error then take note of it..
 			if (@sqlite_last_error($this->dbh))

--- a/sqlite/ez_sql_sqlite3.php
+++ b/sqlite/ez_sql_sqlite3.php
@@ -68,7 +68,10 @@
 				$this->show_errors ? trigger_error($php_errormsg,E_USER_WARNING) : null;
 			}
 			else
+			{
 				$return_val = true;
+				$this->conn_queries = 0;
+			}
 
 			return $return_val;			
 		}
@@ -141,7 +144,7 @@
 
 			// Perform the query via std mysql_query function..
 			$this->result = $this->dbh->query($query);
-			$this->num_queries++;
+			$this->count(true, true);
 
 			// If there is an error then take note of it..
 			if (@$this->dbh->lastErrorCode())

--- a/sqlsrv/ez_sql_sqlsrv.php
+++ b/sqlsrv/ez_sql_sqlsrv.php
@@ -111,6 +111,8 @@
 				$this->dbpassword = $dbpassword;
 				$this->dbhost = $dbhost;
 				$return_val = true;
+
+				$this->conn_queries = 0;
 			}
 
 			return $return_val;
@@ -177,7 +179,7 @@
 			$this->last_query = $query;
 
 			// Count how many queries there have been
-			$this->num_queries++;
+			$this->count(true, true);
 
 			// Use core file cache function
 			if ( $cache = $this->get_cache($query) )
@@ -376,6 +378,7 @@
 
 		function disconnect()
 		{
+			$this->conn_queries = 0;
 			@sqlsrv_close($this->dbh);
 		}
 

--- a/sybase/ez_sql_sybase.php
+++ b/sybase/ez_sql_sybase.php
@@ -100,6 +100,8 @@
 				$this->dbpassword = $dbpassword;
 				$this->dbhost = $dbhost;
 				$return_val = true;
+
+				$this->conn_queries = 0;
 			}
 
 			return $return_val;
@@ -201,7 +203,7 @@
 			$this->last_query = $query;
 
 			// Count how many queries there have been
-			$this->num_queries++;
+			$this->count(true, true);
 
 			// Use core file cache function
 			if ( $cache = $this->get_cache($query) )


### PR DESCRIPTION
I've added a new way of counting queries. The differences are as follows

* `$this->num_queries` now holds amount of queries that were run since object's creation
* `$this->conn_queries` now holds amount of queries that were run since the last time object connected to DB (it is reset every time the `$this->disconnect()` and `$this->connect()` functions are called)
* A new function `$this->count()` has been added with 2 arguments:
  1. Controls whether the function should return total number of queries (default) or only since last connect
  2. Set to true to increase the query count (internal usage)


This change also fixes #72

P.S. While making changes I've found that not every class implements `$this->disconnect()`. Is this supposed to be so?