### PR TITLE
Use new query counter for disconnection test in Cubrid/MySQLi

### DIFF
--- a/cubrid/ez_sql_cubrid.php
+++ b/cubrid/ez_sql_cubrid.php
@@ -142,7 +142,7 @@
 		function query($query)
 		{
 			// This keeps the connection alive for very long running scripts
-			if ( $this->num_queries >= 500 )
+			if ( $this->count(false) >= 500 )
 			{
 				$this->disconnect();
 				$this->connect($this->dbuser,$this->dbpassword,$this->dbname,$this->dbhost,$this->dbport);

--- a/mysqli/ez_sql_mysqli.php
+++ b/mysqli/ez_sql_mysqli.php
@@ -206,7 +206,7 @@
 		{
 
 			// This keeps the connection alive for very long running scripts
-			if ( $this->num_queries >= 500 )
+			if ( $this->count(false) >= 500 )
 			{
 				$this->disconnect();
 				$this->quick_connect($this->dbuser,$this->dbpassword,$this->dbname,$this->dbhost,$this->dbport,$this->encoding);


### PR DESCRIPTION
In a previous set of pull requests a new query counter has been implemented to avoid a reconnection to the SQL server at every query subsequent to (and including) the 500th.

However, the disconnect/reconnect test only uses this new mechanism for the classic MySQL connector. Therefore, the other two connectors that do reconnections after 500 queries (Cubrid and MySQLi) will disconnect and reconnect after every query after the 500th, as well as every 500th query.

This pull request resolves this issue by copying over the test from the MySQL connector into Cubrid and MySQLi, so reconnections occur only after every 500th query.