### PR TITLE
pdo and core constructor update

### DIFF
--- a/pdo/ez_sql_pdo.php
+++ b/pdo/ez_sql_pdo.php
@@ -39,7 +39,7 @@
 		*  same time as initialising the ezSQL_pdo class
 		*/
 
-		function ezSQL_pdo($dsn='', $user='', $password='', $ssl=array())
+		function __construct($dsn='', $user='', $password='', $ssl=array())
 		{
 			// Turn on track errors 
 			ini_set('track_errors',1);

--- a/shared/ez_sql_core.php
+++ b/shared/ez_sql_core.php
@@ -59,7 +59,7 @@
 		*  Constructor
 		*/
 
-		function ezSQLcore()
+		function __construct()
 		{
 		}
 


### PR DESCRIPTION
PHP 7.0: Deprecated: Methods with the same name as their class will not be constructors