### PR TITLE
gets rid of PHP notices if the ezSQL constants have been defined and …

### DIFF
--- a/shared/ez_sql_core.php
+++ b/shared/ez_sql_core.php
@@ -14,10 +14,10 @@
 	*  ezSQL Constants
 	*/
 
-	define('EZSQL_VERSION', '2.17');
-	define('OBJECT', 'OBJECT');
-	define('ARRAY_A', 'ARRAY_A');
-	define('ARRAY_N', 'ARRAY_N');
+	defined('EZSQL_VERSION') or define('EZSQL_VERSION', '2.17');
+	defined('OBJECT') or define('OBJECT', 'OBJECT');
+	defined('ARRAY_A') or define('ARRAY_A', 'ARRAY_A');
+	defined('ARRAY_N') or define('ARRAY_N', 'ARRAY_N');
 
 	/**********************************************************************
 	*  Core class containg common functions to manipulate query result


### PR DESCRIPTION
rewrote the setting of the ezSQL constants to fix the issue #104 