### PR TITLE
Fix PHP4 style constructs

### DIFF
--- a/cubrid/ez_sql_cubrid.php
+++ b/cubrid/ez_sql_cubrid.php
@@ -42,7 +42,7 @@
 		*  same time as initialising the ezSQL_cubrid class
 		*/
 
-		function ezSQL_cubrid($dbuser='', $dbpassword='', $dbname='', $dbhost='localhost', $dbport=33000)
+		function __construct($dbuser='', $dbpassword='', $dbname='', $dbhost='localhost', $dbport=33000)
 		{
 			$this->dbuser = $dbuser;
 			$this->dbpassword = $dbpassword;

--- a/mssql/ez_sql_mssql.php
+++ b/mssql/ez_sql_mssql.php
@@ -49,7 +49,7 @@
 		*  same time as initialising the ezSQL_mssql class
 		*/
 
-		function ezSQL_mssql($dbuser='', $dbpassword='', $dbname='', $dbhost='localhost', $convertMySqlToMSSqlQuery=true)
+		function __construct($dbuser='', $dbpassword='', $dbname='', $dbhost='localhost', $convertMySqlToMSSqlQuery=true)
 		{
 			$this->dbuser = $dbuser;
 			$this->dbpassword = $dbpassword;

--- a/mysqli/ez_sql_mysqli.php
+++ b/mysqli/ez_sql_mysqli.php
@@ -161,7 +161,7 @@
 						$charsets[] = $row["Charset"];
 					}
 					if(in_array($encoding,$charsets)){
-						$this->dbh->query("SET NAMES '".$encoding."'");						
+						$this->dbh->set_charset($encoding);
 					}
 				}
 				

--- a/oracle8_9/ez_sql_oracle8_9.php
+++ b/oracle8_9/ez_sql_oracle8_9.php
@@ -40,7 +40,7 @@
 		*  same time as initialising the ezSQL_oracle8_9 class
 		*/
 
-		function ezSQL_oracle8_9($dbuser='', $dbpassword='', $dbname='')
+		function __construct($dbuser='', $dbpassword='', $dbname='')
 		{
 
 			// Turn on track errors

--- a/pdo/ez_sql_pdo.php
+++ b/pdo/ez_sql_pdo.php
@@ -34,7 +34,6 @@
 		var $password;
 		var $rows_affected = false;
 		var $insert_id;
-		var $last_query;
 		var $last_result;
 		var $num_rows;
 		/**********************************************************************

--- a/pdo/ez_sql_pdo.php
+++ b/pdo/ez_sql_pdo.php
@@ -33,7 +33,10 @@
 		var $user;
 		var $password;
 		var $rows_affected = false;
-
+		var $insert_id;
+		var $last_query;
+		var $last_result;
+		var $num_rows;
 		/**********************************************************************
 		*  Constructor - allow the user to perform a quick connect at the 
 		*  same time as initialising the ezSQL_pdo class

--- a/postgresql/ez_sql_postgresql.php
+++ b/postgresql/ez_sql_postgresql.php
@@ -45,7 +45,7 @@
 		*  same time as initialising the ezSQL_postgresql class
 		*/
 
-		function ezSQL_postgresql($dbuser='', $dbpassword='', $dbname='', $dbhost='localhost', $port='5432')
+		function __construct($dbuser='', $dbpassword='', $dbname='', $dbhost='localhost', $port='5432')
 		{
 			$this->dbuser = $dbuser;
 			$this->dbpassword = $dbpassword;

--- a/shared/ez_sql_core_2.1_debughack_0.2alpha.php
+++ b/shared/ez_sql_core_2.1_debughack_0.2alpha.php
@@ -98,7 +98,7 @@
 		*  Constructor
 		*/
 
-		function ezSQLcore()
+		function __construct()
 		{
 		}
 

--- a/shared/ez_sql_core_202console.php
+++ b/shared/ez_sql_core_202console.php
@@ -64,7 +64,7 @@
 		*  Constructor
 		*/
 
-		function ezSQLcore()
+		function __construct()
 		{
 		}
 

--- a/sqlite/ez_sql_sqlite.php
+++ b/sqlite/ez_sql_sqlite.php
@@ -36,7 +36,7 @@
 		*  same time as initialising the ezSQL_sqlite class
 		*/
 
-		function ezSQL_sqlite($dbpath='', $dbname='')
+		function __construct($dbpath='', $dbname='')
 		{
 			// Turn on track errors 
 			ini_set('track_errors',1);

--- a/sqlite/ez_sql_sqlite3.php
+++ b/sqlite/ez_sql_sqlite3.php
@@ -36,7 +36,7 @@
 		*  same time as initialising the ezSQL_sqlite3 class
 		*/
 
-		function ezSQL_sqlite3($dbpath='', $dbname='')
+		function __construct($dbpath='', $dbname='')
 		{
 			// Turn on track errors 
 			ini_set('track_errors',1);

--- a/sqlsrv/ez_sql_sqlsrv.php
+++ b/sqlsrv/ez_sql_sqlsrv.php
@@ -62,7 +62,7 @@
 		*  same time as initialising the ezSQL_mssql class
 		*/
 
-		function ezSQL_sqlsrv($dbuser='', $dbpassword='', $dbname='', $dbhost='localhost', $convertMySqlToMSSqlQuery=true)
+		function __construct($dbuser='', $dbpassword='', $dbname='', $dbhost='localhost', $convertMySqlToMSSqlQuery=true)
 		{
 			$this->dbuser = $dbuser;
 			$this->dbpassword = $dbpassword;

--- a/sybase/ez_sql_sybase.php
+++ b/sybase/ez_sql_sybase.php
@@ -50,7 +50,7 @@
 		*  same time as initialising the ezSQL_sybase class
 		*/
 
-		function ezSQL_sybase($dbuser='', $dbpassword='', $dbname='', $dbhost='localhost', $convertMySqlTosybaseQuery=true)
+		function __construct($dbuser='', $dbpassword='', $dbname='', $dbhost='localhost', $convertMySqlTosybaseQuery=true)
 		{
 			$this->dbuser = $dbuser;
 			$this->dbpassword = $dbpassword;


### PR DESCRIPTION
Fixing the old PHP4 style constructs across the various drivers for PHP7 comparability.

I left the mysql and mssql drivers as is given these are both depreciated.