### PR TITLE
BugFix: Passed missing ssl argument to connect

### DIFF
--- a/pdo/ez_sql_pdo.php
+++ b/pdo/ez_sql_pdo.php
@@ -48,7 +48,7 @@
 			
 			if ( $dsn && $user )
 			{
-				$this->connect($dsn, $user, $password);
+				$this->connect($dsn, $user, $password, $ssl);
 			}
 		}
 


### PR DESCRIPTION
ssl argument was simply ignored and had not been passed down to connect method! So could not work with SSL connections.