### PR TITLE
PostgreSQL "returning" support

### DIFF
--- a/postgresql/ez_sql_postgresql.php
+++ b/postgresql/ez_sql_postgresql.php
@@ -224,8 +224,17 @@
 					$this->insert_id = $insert_row[0];
 				}
 
-				// Return number fo rows affected
+				// Return number for rows affected
 				$return_val = $this->rows_affected;
+				
+				if ( preg_match("/returning/smi",$query) )
+				{
+					while ( $row = @pg_fetch_object($this->result) )
+					{
+						$return_valx[] = $row;
+					}
+					$return_val = $return_valx;
+				}
 			}
 			// Query was a select
 			else


### PR DESCRIPTION
PostgreSQL has an amazing clause called "RETURNING *", which returns affected row/s as row after successfully insert/update/delete. This class returns only affected row count and affected row id only for "insert" and "replace". With these additions it supports now "RETURNING *" clause too. 

It maybe not work properly, if you have any other "returning" keyword in your query phase.
 
For more info please see ; https://www.postgresql.org/docs/9.5/static/dml-returning.html

Ps: I use it like this for a short time. I will replace it with a ORM soon.