### PR TITLE
continue fixBug: Error when trying to use $db->vardump()

### DIFF
--- a/lib/ezsqlModel.php
+++ b/lib/ezsqlModel.php
@@ -476,7 +476,7 @@ class ezsqlModel extends ezQuery implements ezsqlModelInterface
 		}
 
 		echo "<b>Last Rows Returned:</b><br>";
-		echo ((!empty($this->last_result) && \count($this->last_result) > 0)  ? print_r($this->last_result[0]) : '')."\n";
+		echo ((!empty($this->last_result) && \count($this->last_result) > 0)  ? print_r($this->last_result[0]) : 'No rows returned')."\n";
 		echo "</font></pre></font></blockquote></td></tr></table>";//.$this->donation();
 		echo "\n<hr size=1 noshade color=dddddd>";
 

--- a/lib/ezsqlModel.php
+++ b/lib/ezsqlModel.php
@@ -8,7 +8,7 @@ use ezsql\ezsqlModelInterface;
 /**
  * Core class containing common functions to manipulate query result
  * sets once returned
- */	
+ */
 class ezsqlModel extends ezQuery implements ezsqlModelInterface
 {
 	protected $isSecure = false;
@@ -22,13 +22,13 @@ class ezsqlModel extends ezQuery implements ezsqlModelInterface
 	 * If set to true (i.e. $db->debug_all = true;) Then it will print out ALL queries and ALL results of your script.
 	 * @var boolean
 	 */
-	protected $debug_all = false;  
-	
+	protected $debug_all = false;
+
 	// same as $debug_all
 	protected $trace = false;
 	protected $debug_called = false;
 	protected $varDump_called = false;
-	
+
 	/**
 	 * Current show error state
 	 * @var boolean
@@ -36,7 +36,7 @@ class ezsqlModel extends ezQuery implements ezsqlModelInterface
 	protected $show_errors = true;
 
 	/**
-	 * Keeps track of exactly how many 'real' (not cached) 
+	 * Keeps track of exactly how many 'real' (not cached)
 	 * queries were executed during the lifetime of the current script
 	 * @var int
 	 */
@@ -47,7 +47,7 @@ class ezsqlModel extends ezQuery implements ezsqlModelInterface
 
 	/**
 	 * Specify a cache dir. Path is taken from calling script
-	 * @var string 
+	 * @var string
 	 */
 	protected $cache_dir = 'tmp'.\_DS.'ez_cache';
 
@@ -55,7 +55,7 @@ class ezsqlModel extends ezQuery implements ezsqlModelInterface
 	 * Disk Cache Setup
 	 * (1. You must create this dir. first!)
 	 * (2. Might need to do chmod 775)
-	 * 
+	 *
 	 * Global override setting to turn disc caching off (but not on)
 	 * @var boolean
 	 */
@@ -69,7 +69,7 @@ class ezsqlModel extends ezQuery implements ezsqlModelInterface
 
 	/**
 	 * if you want to cache EVERYTHING just do..
-	 * 
+	 *
 	 * $use_disk_cache = true;
 	 * $cache_queries = true;
 	 * $cache_timeout = 24;
@@ -84,7 +84,7 @@ class ezsqlModel extends ezQuery implements ezsqlModelInterface
 	protected $cache_inserts = false;
 
 	/**
-     * Log number of rows the query returned  
+     * Log number of rows the query returned
      * @var int Default is null
      */
 	protected $num_rows = null;
@@ -122,13 +122,13 @@ class ezsqlModel extends ezQuery implements ezsqlModelInterface
 	protected $trace_log = array();
 	protected $use_trace_log = false;
 	protected $do_profile = false;
-		
+
 	/**
 	* The last query result
 	* @var object Default is null
 	*/
 	protected $last_result = null;
-		
+
 	/**
 	* Get data from disk cache
 	* @var boolean Default is false
@@ -145,7 +145,7 @@ class ezsqlModel extends ezQuery implements ezsqlModelInterface
 	* Whether the database connection is established, or not
 	* @var boolean Default is false
 	*/
-	protected $_connected = false;    
+	protected $_connected = false;
 
 	/**
 	* Contains the number of affected rows of a query
@@ -157,14 +157,14 @@ class ezsqlModel extends ezQuery implements ezsqlModelInterface
 	* Function called
 	* @var string
 	*/
-	private $func_call; 
+	private $func_call;
 
 	/**
 	* All functions called
-	* @var array 
+	* @var array
 	*/
 	private $all_func_calls = array();
-	
+
 	/**
 	* Constructor
 	*/
@@ -175,7 +175,7 @@ class ezsqlModel extends ezQuery implements ezsqlModelInterface
 
 	/**
 	 * Use for Calling Non-Existent Functions, handling Getters and Setters
-	 * @method set/get{property} - a property that needs to be accessed 
+	 * @method set/get{property} - a property that needs to be accessed
 	 *
 	 * @property-read function
 	 * @property-write args
@@ -187,7 +187,7 @@ class ezsqlModel extends ezQuery implements ezsqlModelInterface
 	{
 		$prefix = \substr($function, 0, 3);
 		$property = \strtolower(substr($function, 3, \strlen($function)));
-		// Todo: make properties PSR-1, add following for backward compatibility 
+		// Todo: make properties PSR-1, add following for backward compatibility
 		//if (\strpos($property, '_') !== false)
 		//	$property = \str_replace('_', '', $property);
 
@@ -209,34 +209,34 @@ class ezsqlModel extends ezQuery implements ezsqlModelInterface
 		}
 		return array( $host, $port );
 	}
-	
+
 	public function register_error(string $err_str, bool $displayError = true)
 	{
 		// Keep track of last error
 		$this->last_error = $err_str;
-		
+
 		// Capture all errors to an error array no matter what happens
 		$this->captured_errors[] = array(
 			'error_str' => $err_str,
 			'query'     => $this->last_query
-		);		
-		
+		);
+
 		if ($this->show_errors && $displayError)
-			\trigger_error(\htmlentities($err_str), \E_USER_WARNING); 
-		
+			\trigger_error(\htmlentities($err_str), \E_USER_WARNING);
+
 		return false;
 	}
-	
+
 	public function show_errors()
 	{
 		$this->show_errors = true;
 	}
-	
+
 	public function hide_errors()
 	{
 		$this->show_errors = false;
 	}
-	
+
 	/**
 	 * Turn on echoing of debug info, for `debug()`
 	 */
@@ -244,7 +244,7 @@ class ezsqlModel extends ezQuery implements ezsqlModelInterface
 	{
 		$this->debug_echo_is_on = true;
 	}
-	
+
 	/**
 	 * Turn off echoing of debug info, the default, for `debug()`
 	 */
@@ -252,7 +252,7 @@ class ezsqlModel extends ezQuery implements ezsqlModelInterface
 	{
 		$this->debug_echo_is_on = false;
 	}
-	
+
 	public function flush()
 	{
 		// Get rid of these
@@ -262,45 +262,45 @@ class ezsqlModel extends ezQuery implements ezsqlModelInterface
 		$this->from_disk_cache = false;
 		$this->clearPrepare();
 	}
-	
+
 	public function log_query(string $query)
 	{
 		// Log how the last function was called
 		$this->func_call = $query;
-		
+
 		// Keep an running Log of all functions called
 		\array_push($this->all_func_calls, $this->func_call);
 	}
-	
+
 	public function get_var(string $query = null, int $x = 0, int $y = 0, bool $use_prepare = false)
-	{		
+	{
 		// Log how the function was called
 		$this->log_query("\$db->get_var(\"$query\",$x,$y)");
-		
+
 		// If there is a query then perform it if not then use cached results..
 		if ( $query) {
 			$this->query($query, $use_prepare);
 		}
-		
+
 		// Extract public out of cached results based x,y values
 		if ( isset($this->last_result[$y]) ) {
 			$values = \array_values(\get_object_vars($this->last_result[$y]));
 		}
-		
+
 		// If there is a value return it else return null
 		return (isset($values[$x]) && $values[$x] !== null) ? $values[$x] :null;
 	}
-	
+
 	public function get_row(string $query = null, $output = OBJECT, int $y = 0, bool $use_prepare = false)
 	{
 		// Log how the function was called
 		$this->log_query("\$db->get_row(\"$query\",$output,$y)");
-		
+
 		// If there is a query then perform it if not then use cached results..
 		if ( $query ) {
 			$this->query($query, $use_prepare);
 		}
-		
+
 		if ( $output == OBJECT ) {
 			// If the output is an object then return object using the row offset..
 			return isset($this->last_result[$y]) ? $this->last_result[$y] : null;
@@ -315,16 +315,16 @@ class ezsqlModel extends ezQuery implements ezsqlModelInterface
 			$this->show_errors ? \trigger_error(" \$db->get_row(string query, output type, int offset) -- Output type must be one of: OBJECT, ARRAY_A, ARRAY_N", \E_USER_WARNING) : null;
 		}
 	}
-	
+
 	public function get_col(string $query = null, int $x = 0, bool $use_prepare = false)
 	{
 		$new_array = array();
-		
+
 		// If there is a query then perform it if not then use cached results..
 		if ( $query ) {
 			$this->query($query, $use_prepare);
 		}
-		
+
 		// Extract the column values
 		if (\is_array($this->last_result)) {
 			$j = \count($this->last_result);
@@ -335,20 +335,20 @@ class ezsqlModel extends ezQuery implements ezsqlModelInterface
 
 		return $new_array;
 	}
-	
-	public function get_results(string $query = null, $output = \OBJECT, 	bool $use_prepare = false) 
+
+	public function get_results(string $query = null, $output = \OBJECT, 	bool $use_prepare = false)
 	{
 		// Log how the function was called
 		$this->log_query("\$db->get_results(\"$query\", $output, $use_prepare)");
-		
+
 		// If there is a query then perform it if not then use cached results..
 		if ( $query ) {
 			$this->query($query, $use_prepare);
 		}
-		
+
 		if ( $output == OBJECT ) {
 			return $this->last_result;
-		} elseif ( $output == \_JSON ) { 
+		} elseif ( $output == \_JSON ) {
 			return \json_encode($this->last_result); // return as json output
 		} elseif ( $output == ARRAY_A || $output == ARRAY_N ) {
 			$new_array = [];
@@ -365,7 +365,7 @@ class ezsqlModel extends ezQuery implements ezsqlModelInterface
 			return $new_array;
 		}
 	}
-	
+
 	public function get_col_info(string $info_type = "name", int $col_offset = -1)
 	{
 		if ( $this->col_info ) {
@@ -376,7 +376,7 @@ class ezsqlModel extends ezQuery implements ezsqlModelInterface
 					$new_array[$i] = $col->{$info_type};
 					$i++;
 				}
-				
+
 				return $new_array;
 			}
 
@@ -384,22 +384,22 @@ class ezsqlModel extends ezQuery implements ezsqlModelInterface
 		}
 	}
 
-	public function create_cache(string $path = null) 
+	public function create_cache(string $path = null)
 	{
 		$cache_dir = empty($path) ? $this->cache_dir : $path;
 		if ( ! \is_dir($cache_dir) ) {
 			$this->cache_dir = $cache_dir;
 			@\mkdir($cache_dir, ('\\' == \DIRECTORY_SEPARATOR ? null : 0755), true);
-		} 
+		}
 	}
 
 	public function store_cache(string $query, bool $is_insert = false)
 	{
 		// The would be cache file for this query
 		$cache_file = $this->cache_dir.\_DS.\md5($query);
-		
+
 		// disk caching of queries
-		if ( $this->use_disk_cache 
+		if ( $this->use_disk_cache
 			&& ( $this->cache_queries && ! $is_insert ) || ( $this->cache_inserts && $is_insert )
 		) {
 			$this->create_cache();
@@ -413,87 +413,87 @@ class ezsqlModel extends ezQuery implements ezsqlModelInterface
 					'num_rows' => $this->num_rows,
 					'return_value' => $this->num_rows,
 				);
-				
+
 				\file_put_contents($cache_file, \serialize($result_cache));
 				if( \file_exists($cache_file . ".updating") )
 					\unlink($cache_file . ".updating");
 			}
 		}
 	}
-	
+
 	public function get_cache(string $query)
 	{
 		// The would be cache file for this query
 		$cache_file = $this->cache_dir.\_DS.\md5($query);
-		
+
 		// Try to get previously cached version
 		if ( $this->use_disk_cache && \file_exists($cache_file) ) {
 			// Only use this cache file if less than 'cache_timeout' (hours)
-			if ( (\time() - \filemtime($cache_file)) > ($this->cache_timeout*3600) 
-				&& !(\file_exists($cache_file . ".updating") 
-				&& (\time() - \filemtime($cache_file . ".updating") < 60)) 
+			if ( (\time() - \filemtime($cache_file)) > ($this->cache_timeout*3600)
+				&& !(\file_exists($cache_file . ".updating")
+				&& (\time() - \filemtime($cache_file . ".updating") < 60))
 			) {
 				\touch($cache_file . ".updating"); // Show that we in the process of updating the cache
 			} else {
 				$result_cache = \unserialize(\file_get_contents($cache_file));
-				
+
 				$this->col_info = $result_cache['col_info'];
 				$this->last_result = $result_cache['last_result'];
 				$this->num_rows = $result_cache['num_rows'];
-				
+
 				$this->from_disk_cache = true;
-				
+
 				// If debug ALL queries
 				$this->trace || $this->debug_all ? $this->debug() : null ;
-				
+
 				return $result_cache['return_value'];
 			}
 		}
 	}
-	
+
 	public function varDump($mixed = null)
 	{
 		// Start output buffering
 		\ob_start();
-		
+
 		echo "<p><table><tr><td bgcolor=ffffff><blockquote><font color=000090>";
 		echo "<pre><font face=arial>";
-		
+
 		if ( ! $this->varDump_called ) {
 			echo "<font color=800080><b>ezSQL</b> (v".EZSQL_VERSION.") <b>Variable Dump..</b></font>\n\n";
 		}
-		
+
 		$var_type = \gettype ($mixed);
 		\print_r(($mixed?$mixed:"<font color=red>No Value / False</font>"));
 		echo "\n\n<b>Type:</b> " . \ucfirst($var_type) . "\n";
 		echo "<b>Last Query</b> [$this->num_queries]<b>:</b> ".($this->last_query?$this->last_query:"NULL")."\n";
 		echo "<b>Last Function Call:</b> " . ($this->func_call?$this->func_call:"None")."\n";
-		
+
 		if (\count($this->all_func_calls) > 1) {
-			echo "<b>List of All Function Calls:</b><br>"; 
+			echo "<b>List of All Function Calls:</b><br>";
 			foreach($this->all_func_calls as $func_string)
 			echo "  " . $func_string ."<br>\n";
 		}
-		
+
 		echo "<b>Last Rows Returned:</b><br>";
-		echo ((\count($this->last_result) > 0)  ? print_r($this->last_result[0]) : '')."\n";
+		echo ((!empty($this->last_result) && \count($this->last_result) > 0)  ? print_r($this->last_result[0]) : '')."\n";
 		echo "</font></pre></font></blockquote></td></tr></table>";//.$this->donation();
 		echo "\n<hr size=1 noshade color=dddddd>";
-		
+
 		// Stop output buffering and capture debug HTML
 		$html = \ob_get_contents();
 		\ob_end_clean();
-		
+
 		// Only echo output if it is turned on
 		if ( $this->debug_echo_is_on ) {
 			echo $html;
 		}
-		
+
 		$this->varDump_called = true;
-		
+
 		return $html;
 	}
-	
+
 	/**
 	* @internal ezsqlModel::varDump
 	*/
@@ -501,38 +501,38 @@ class ezsqlModel extends ezQuery implements ezsqlModelInterface
 	{
 		return $this->varDump($mixed);
 	}
-	
+
 	public function debug($print_to_screen = true)
 	{
 		// Start output buffering
 		\ob_start();
-		
+
 		echo "\n\n<blockquote>";
-		
+
 		// Only show ezSQL credits once..
 		if ( ! $this->debug_called ) {
 			echo "<font color=800080 face=arial size=2><b>ezSQL</b> (v".EZSQL_VERSION.")\n <b>Debug.. \n</b></font><p>";
 		}
-		
+
 		if ( $this->last_error ) {
 			echo "<font face=arial size=2 color=000099><b>Last Error --</b> [<font color=000000><b>$this->last_error \n</b></font>]<p>";
 		}
-		
+
 		if ( $this->from_disk_cache ) {
 			echo "<font face=arial size=2 color=000099><b>Results retrieved from disk cache</b></font><p>\n";
 		}
-		
+
 		echo "<font face=arial size=2 color=000099><b>Query</b> [$this->num_queries]  \n<b>--</b>";
 		echo "[<font color=000000><b>$this->last_query \n</b></font>]</font><p>";
-		
+
 		echo "<font face=arial size=2 color=000099><b>Query Result..</b></font>\n";
 		echo "<blockquote>\n";
-		
+
 		if ( $this->col_info ) {
 			// Results top rows
 			echo "<table cellpadding=5 cellspacing=1 bgcolor=555555>\n";
-			echo "<tr bgcolor=eeeeee><td nowrap valign=bottom><font color=555599 face=arial size=2><b>(row)</b></font></td>\n";			
-			
+			echo "<tr bgcolor=eeeeee><td nowrap valign=bottom><font color=555599 face=arial size=2><b>(row)</b></font></td>\n";
+
 			for ( $i=0, $j=count($this->col_info); $i < $j; $i++ ) {
 				echo "<td nowrap align=left valign=top><font size=1 color=555599 face=arial>\n";
 				/* when selecting count(*) the maxlengh is not set, size is set instead. */
@@ -550,65 +550,65 @@ class ezsqlModel extends ezQuery implements ezsqlModelInterface
 				if (isset($this->col_info[$i]->name))
 					echo "{$this->col_info[$i]->name}";
 
-				echo "\n</span></td>";					
+				echo "\n</span></td>";
 			}
 			echo "</tr>\n";
-			
+
 			// print main results
 			if ( $this->last_result ) {
 				$i = 0;
 				foreach ( $this->get_results(null, ARRAY_N) as $one_row ) {
 					$i++;
 					echo "<tr bgcolor=ffffff><td bgcolor=eeeeee nowrap align=middle><font size=2 color=555599 face=arial>$i \n</font></td>";
-					
+
 					foreach ( $one_row as $item ) {
 						echo "<td nowrap><font face=arial size=2>$item \n</font></td>";
 					}
 					echo "</tr>\n";
 				}
 			} else {
-				// if last result 
+				// if last result
 				echo "<tr bgcolor=ffffff><td colspan=".(\count($this->col_info) + 1)."><font face=arial size=2>No Results</font></td></tr>\n";
 			}
-			
+
 			echo "</table>\n";
 		} else {
 			// if col_info
 			echo "<font face=arial size=2>No Results \n</font>";
 		}
-		
+
 		//echo "</blockquote></blockquote>".$this->donation()."<hr noshade color=dddddd size=1>";
-		
+
 		// Stop output buffering and capture debug HTML
 		$html = \ob_get_contents();
 		\ob_end_clean();
-		
+
 		// Only echo output if it is turned on
 		if ( $this->debug_echo_is_on && $print_to_screen) {
 			echo $html;
 		}
-		
+
 		$this->debug_called = true;
-		
+
 		return $html;
 	}
-		
+
 	public function timer_get_cur()
 	{
 		list($usec, $sec) = \explode(" ",\microtime());
 		return ((float)$usec + (float)$sec);
 	}
-	
+
 	public function timer_start($timer_name)
 	{
 		$this->timers[$timer_name] = $this->timer_get_cur();
 	}
-	
+
 	public function timer_elapsed($timer_name)
 	{
 		return \round($this->timer_get_cur() - $this->timers[$timer_name],2);
 	}
-	
+
 	public function timer_update_global($timer_name)
 	{
 		if ( $this->do_profile ) {
@@ -619,22 +619,22 @@ class ezsqlModel extends ezQuery implements ezsqlModelInterface
 		}
 		$this->total_query_time += $this->timer_elapsed($timer_name);
 	}
-	
-	public function count($all = true, $increase = false) 
+
+	public function count($all = true, $increase = false)
 	{
 		if ($increase) {
 			$this->num_queries++;
 			$this->conn_queries++;
 		}
-		
+
 		return ($all) ? $this->num_queries : $this->conn_queries;
 	}
 
     public function secureSetup(
-        string $key = 'certificate.key', 
-        string $cert = 'certificate.crt', 
-        string $ca = 'cacert.pem', 
-        string $path = '.'.\_DS) 
+        string $key = 'certificate.key',
+        string $cert = 'certificate.crt',
+        string $ca = 'cacert.pem',
+        string $path = '.'.\_DS)
     {
 		if (! \file_exists($path.$cert) || ! \file_exists($path.$key)) {
 			$vendor = \getVendor();
@@ -652,7 +652,7 @@ class ezsqlModel extends ezQuery implements ezsqlModelInterface
 		$this->sslPath = $path;
 	}
 
-    public function secureReset() 
+    public function secureReset()
     {
         $this->isSecure = false;
         $this->sslKey = null;
@@ -662,17 +662,17 @@ class ezsqlModel extends ezQuery implements ezsqlModelInterface
 		$this->secureOptions = null;
 	}
 
-    public function isConnected() 
+    public function isConnected()
 	{
         return $this->_connected;
      } // isConnected
 
-	public function affectedRows() 
+	public function affectedRows()
 	{
         return $this->_affectedRows;
 	} // affectedRows
 
-	public function queryResult() 
+	public function queryResult()
 	{
         return $this->last_result;
 	}


### PR DESCRIPTION
Add fix to #163 where it would return an error if `$this->last_result` was not an array or object. Now checks if it is empty and allows it to continue if it is.