### PR TITLE
fixBug: Conditional Stacked Functions in selecting

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,16 +87,16 @@ create('profile',
 ---
 
     innerJoin(string $leftTable = null, string $rightTable = null,
-        string $leftColumn = null, string $rightColumn = null, $condition = EQ);
+        string $leftColumn = null, string $rightColumn = null, string $tableAs = null, $condition = EQ);
 
     leftJoin(string $leftTable = null, string $rightTable = null,
-        string $leftColumn = null, string $rightColumn = null, $condition = EQ);
+        string $leftColumn = null, string $rightColumn = null, string $tableAs = null, $condition = EQ);
 
     rightJoin(string $leftTable = null, string $rightTable = null,
-        string $leftColumn = null, string $rightColumn = null, $condition = EQ);
+        string $leftColumn = null, string $rightColumn = null, string $tableAs = null, $condition = EQ);
 
     fullJoin(string $leftTable = null, string $rightTable = null,
-        string $leftColumn = null, string $rightColumn = null, $condition = EQ);
+        string $leftColumn = null, string $rightColumn = null, string $tableAs = null, $condition = EQ);
 ---
 
 ```php
@@ -178,7 +178,7 @@ foreach ($result as $row) {
 $result = $db->selecting('profile', 'name, email',
     // Conditionals can also be called, stacked with other functions like:
     //  innerJoin(), leftJoin(), rightJoin(), fullJoin()
-    //      as (leftTable, rightTable, leftColumn, rightColumn, equal condition),
+    //      as (leftTable, rightTable, leftColumn, rightColumn, tableAs, equal condition),
     //  where( eq( columns, values, _AND ), like( columns, _d ) ),
     //  groupBy( columns ),
     //  having( between( columns, values1, values2 ) ),

--- a/lib/ezFunctions.php
+++ b/lib/ezFunctions.php
@@ -94,25 +94,25 @@ if (!function_exists('ezFunctions')) {
     }
 
     function createCertificate(
-        string $privatekeyFile = 'certificate.key', 
-        string $certificateFile = 'certificate.crt', 
-        string $signingFile = 'certificate.csr', 
-        // string $caCertificate = null, 
-        string $ssl_path = null, 
+        string $privatekeyFile = 'certificate.key',
+        string $certificateFile = 'certificate.crt',
+        string $signingFile = 'certificate.csr',
+        // string $caCertificate = null,
+        string $ssl_path = null,
         array $details = ["commonName" => "localhost"]
-    ) 
+    )
     {
         return ezQuery::createCertificate($privatekeyFile, $certificateFile, $signingFile, $ssl_path, $details);
     }
 
 	/**
      * Creates an array from expressions in the following format
-     * 
+     *
      * @param strings $x, - The left expression.
-     * @param strings $operator, - One of 
-     *      '<', '>', '=', '!=', '>=', '<=', '<>', 'IN',, 'NOT IN', 'LIKE', 
+     * @param strings $operator, - One of
+     *      '<', '>', '=', '!=', '>=', '<=', '<>', 'IN',, 'NOT IN', 'LIKE',
      *      'NOT LIKE', 'BETWEEN', 'NOT BETWEEN', 'IS', 'IS NOT', or  the constants above.
-     * 
+     *
      * @param strings $y, - The right expression.
      * @param strings $and, - combine additional expressions with,  'AND','OR', 'NOT', 'AND NOT'.
      * @param strings $args - for any extras
@@ -121,10 +121,10 @@ if (!function_exists('ezFunctions')) {
      *  {
      *          return array($x, $operator, $y, $and, ...$args);
      * }
-     * 
+     *
      * @return array
      */
-    
+
     /**
      * Creates an equality comparison expression with the given arguments.
      */
@@ -154,7 +154,7 @@ if (!function_exists('ezFunctions')) {
         \array_push($expression, $x, \NE, $y, $and, ...$args);
         return $expression;
     }
-    
+
     /**
      * Creates a lower-than comparison expression with the given arguments.
      */
@@ -274,7 +274,7 @@ if (!function_exists('ezFunctions')) {
         \array_push($expression, $x, \_notBETWEEN, $y, $y2, \_AND, ...$args);
         return $expression;
     }
-        
+
     /**
     * Using global class instances, setup functions to call class methods directly.
     *
@@ -287,7 +287,7 @@ if (!function_exists('ezFunctions')) {
         if ($ezSQL instanceOf DatabaseInterface) {
 			$ezInstance = $ezSQL;
             $status = true;
-		} 
+		}
 
         return $status;
     }
@@ -305,164 +305,168 @@ if (!function_exists('ezFunctions')) {
 
     function cleanInput($string) {
         return ezQuery::clean($string);
-    } 
+    }
 
     function select($table = '', $columns = '*', ...$args) {
         $ezQuery = \getInstance();
-        return ($ezQuery instanceOf DatabaseInterface) 
-            ? $ezQuery->selecting($table, $columns, ...$args) 
+        return ($ezQuery instanceOf DatabaseInterface)
+            ? $ezQuery->selecting($table, $columns, ...$args)
             : false;
-    } 
-    
+    }
+
     function select_into($table, $columns = '*', $old = null, ...$args) {
         $ezQuery = \getInstance();
-        return ($ezQuery instanceOf DatabaseInterface) 
-            ? $ezQuery->select_into($table, $columns, $old, ...$args) 
+        return ($ezQuery instanceOf DatabaseInterface)
+            ? $ezQuery->select_into($table, $columns, $old, ...$args)
             : false;
-    } 
-    
+    }
+
     function insert_select($totable = '', $columns = '*', $fromTable, $from = '*', ...$args) {
         $ezQuery = \getInstance();
-        return ($ezQuery instanceOf DatabaseInterface) 
-            ? $ezQuery->insert_select($totable, $columns, $fromTable, $from, ...$args) 
+        return ($ezQuery instanceOf DatabaseInterface)
+            ? $ezQuery->insert_select($totable, $columns, $fromTable, $from, ...$args)
             : false;
-    }     
-    
+    }
+
     function create_select($table, $from, $old = null, ...$args) {
         $ezQuery = \getInstance();
-        return ($ezQuery instanceOf DatabaseInterface) 
-            ? $ezQuery->create_select($table, $from, $old, ...$args) 
+        return ($ezQuery instanceOf DatabaseInterface)
+            ? $ezQuery->create_select($table, $from, $old, ...$args)
             : false;
-    }  
-    
+    }
+
     function where( ...$args) {
         $ezQuery = \getInstance();
-        return ($ezQuery instanceOf DatabaseInterface) 
-            ? $ezQuery->where( ...$args) 
+        return ($ezQuery instanceOf DatabaseInterface)
+            ? $ezQuery->where( ...$args)
             : false;
-    } 
-    
+    }
+
     function groupBy($groupBy) {
         $ezQuery = \getInstance();
-        return ($ezQuery instanceOf DatabaseInterface) 
-            ? $ezQuery->groupBy($groupBy) 
+        return ($ezQuery instanceOf DatabaseInterface)
+            ? $ezQuery->groupBy($groupBy)
             : false;
-    } 
-    
+    }
+
     function having( ...$args) {
         $ezQuery = \getInstance();
-        return ($ezQuery instanceOf DatabaseInterface) 
-            ? $ezQuery->having( ...$args) 
+        return ($ezQuery instanceOf DatabaseInterface)
+            ? $ezQuery->having( ...$args)
             : false;
     }
 
     function innerJoin(
         $leftTable = '',
-        $rightTable = '', 
-        $leftColumn = null, 
-        $rightColumn = null, 
+        $rightTable = '',
+        $leftColumn = null,
+        $rightColumn = null,
+        $tableAs = null,
         $condition = \EQ
     ) {
         $ezQuery = \getInstance();
-        return ($ezQuery instanceOf DatabaseInterface) 
-            ? $ezQuery->innerJoin($leftTable, $rightTable, $leftColumn, $rightColumn, $condition) 
+        return ($ezQuery instanceOf DatabaseInterface)
+            ? $ezQuery->innerJoin($leftTable, $rightTable, $leftColumn, $rightColumn, $tableAs, $condition)
             : false;
     }
 
     function leftJoin(
         $leftTable = '',
-        $rightTable = '', 
-        $leftColumn = null, 
-        $rightColumn = null, 
+        $rightTable = '',
+        $leftColumn = null,
+        $rightColumn = null,
+        $tableAs = null,
         $condition = \EQ
     ) {
         $ezQuery = \getInstance();
-        return ($ezQuery instanceOf DatabaseInterface) 
-            ? $ezQuery->leftJoin($leftTable, $rightTable, $leftColumn, $rightColumn, $condition) 
+        return ($ezQuery instanceOf DatabaseInterface)
+            ? $ezQuery->leftJoin($leftTable, $rightTable, $leftColumn, $rightColumn, $tableAs, $condition)
             : false;
     }
 
     function rightJoin(
         $leftTable = '',
-        $rightTable = '', 
-        $leftColumn = null, 
-        $rightColumn = null, 
+        $rightTable = '',
+        $leftColumn = null,
+        $rightColumn = null,
+        $tableAs = null,
         $condition = \EQ
     ) {
         $ezQuery = \getInstance();
-        return ($ezQuery instanceOf DatabaseInterface) 
-            ? $ezQuery->rightJoin($leftTable, $rightTable, $leftColumn, $rightColumn, $condition) 
+        return ($ezQuery instanceOf DatabaseInterface)
+            ? $ezQuery->rightJoin($leftTable, $rightTable, $leftColumn, $rightColumn, $tableAs, $condition)
             : false;
     }
 
     function fullJoin(
         $leftTable = '',
-        $rightTable = '', 
-        $leftColumn = null, 
-        $rightColumn = null, 
+        $rightTable = '',
+        $leftColumn = null,
+        $rightColumn = null,
+        $tableAs = null,
         $condition = \EQ
     ) {
         $ezQuery = \getInstance();
-        return ($ezQuery instanceOf DatabaseInterface) 
-            ? $ezQuery->fullJoin($leftTable, $rightTable, $leftColumn, $rightColumn, $condition) 
+        return ($ezQuery instanceOf DatabaseInterface)
+            ? $ezQuery->fullJoin($leftTable, $rightTable, $leftColumn, $rightColumn, $tableAs, $condition)
             : false;
     }
 
     function union($table = '', $columnFields = '*', ...$conditions) {
         $ezQuery = \getInstance();
-        return ($ezQuery instanceOf DatabaseInterface) 
-            ? $ezQuery->union($table, $columnFields, ...$conditions) 
+        return ($ezQuery instanceOf DatabaseInterface)
+            ? $ezQuery->union($table, $columnFields, ...$conditions)
             : false;
-    } 
+    }
 
     function unionAll($table = '', $columnFields = '*', ...$conditions) {
         $ezQuery = \getInstance();
-        return ($ezQuery instanceOf DatabaseInterface) 
-            ? $ezQuery->unionAll($table, $columnFields, ...$conditions) 
+        return ($ezQuery instanceOf DatabaseInterface)
+            ? $ezQuery->unionAll($table, $columnFields, ...$conditions)
             : false;
-    } 
+    }
 
     function orderBy($orderBy, $order) {
         $ezQuery = \getInstance();
-        return ($ezQuery instanceOf DatabaseInterface) 
-            ? $ezQuery->orderBy($orderBy, $order) 
+        return ($ezQuery instanceOf DatabaseInterface)
+            ? $ezQuery->orderBy($orderBy, $order)
             : false;
-    } 
+    }
 
     function limit($numberOf, $offset = null) {
         $ezQuery = \getInstance();
-        return ($ezQuery instanceOf DatabaseInterface) 
-            ? $ezQuery->limit($numberOf, $offset) 
+        return ($ezQuery instanceOf DatabaseInterface)
+            ? $ezQuery->limit($numberOf, $offset)
             : false;
-    } 
-    
+    }
+
     function insert($table = '', $keyValue) {
         $ezQuery = \getInstance();
-        return ($ezQuery instanceOf DatabaseInterface) 
-            ? $ezQuery->insert($table, $keyValue) 
+        return ($ezQuery instanceOf DatabaseInterface)
+            ? $ezQuery->insert($table, $keyValue)
             : false;
-    } 
-    
+    }
+
     function update($table = '', $keyValue, ...$args) {
         $ezQuery = \getInstance();
-        return ($ezQuery instanceOf DatabaseInterface) 
-            ? $ezQuery->update($table, $keyValue, ...$args) 
+        return ($ezQuery instanceOf DatabaseInterface)
+            ? $ezQuery->update($table, $keyValue, ...$args)
             : false;
-    } 
-    
+    }
+
     function deleting($table = '', ...$args) {
         $ezQuery = \getInstance();
-        return ($ezQuery instanceOf DatabaseInterface) 
-            ? $ezQuery->delete($table, ...$args) 
+        return ($ezQuery instanceOf DatabaseInterface)
+            ? $ezQuery->delete($table, ...$args)
             : false;
-    } 
-        
+    }
+
     function replace($table = '', $keyValue) {
         $ezQuery = \getInstance();
-        return ($ezQuery instanceOf DatabaseInterface) 
-            ? $ezQuery->replace($table, $keyValue) 
+        return ($ezQuery instanceOf DatabaseInterface)
+            ? $ezQuery->replace($table, $keyValue)
             : false;
-    }  
+    }
 
     function ezFunctions() {
         return true;

--- a/lib/ezQuery.php
+++ b/lib/ezQuery.php
@@ -306,11 +306,11 @@ class ezQuery implements ezQueryInterface
             $tableAs = $rightTable;
 
         if (\is_string($leftColumn) && empty($rightColumn))
-            $onCondition = ' ON ' . $leftTable . '.' . $leftColumn . ' ' . $condition . ' ' . $tableAs . '.' . $leftColumn;
+            $onCondition = ' ON ' . $leftTable . '.' . $leftColumn . ' = ' . $tableAs . '.' . $leftColumn;
         elseif ($condition !== \EQ)
             $onCondition = ' ON ' . $leftTable . '.' . $leftColumn . ' ' . $condition . ' ' . $tableAs . '.' . $rightColumn;
         else
-            $onCondition = ' ON ' . $leftTable . '.' . $leftColumn . ' ' . $condition . ' ' . $tableAs . '.' . $rightColumn;
+            $onCondition = ' ON ' . $leftTable . '.' . $leftColumn . ' = ' . $tableAs . '.' . $rightColumn;
 
         return ' ' . $type . ' JOIN ' . $rightTable . ' AS ' . $tableAs . ' ' . $onCondition;
     }

--- a/lib/ezQuery.php
+++ b/lib/ezQuery.php
@@ -6,14 +6,14 @@ use ezsql\ezSchema;
 use ezsql\ezQueryInterface;
 
 class ezQuery implements ezQueryInterface
-{ 		
+{
 	protected $select_result = true;
 	protected $prepareActive = false;
     protected $preparedValues = array();
     protected $insert_id = null;
-    
+
 	private $fromTable = null;
-    private $isWhere = true;    
+    private $isWhere = true;
     private $isInto = false;
     private $whereSQL = null;
     private $combineWith = null;
@@ -21,8 +21,8 @@ class ezQuery implements ezQueryInterface
     public function __construct()
     {
     }
- 
-    public static function clean($string) 
+
+    public static function clean($string)
     {
         $patterns = array( // strip out:
             '@<script[^>]*?>.*?</script>@si', // Strip out javascript
@@ -30,25 +30,25 @@ class ezQuery implements ezQueryInterface
             '@<style[^>]*?>.*?</style>@siU',  // Strip style tags properly
             '@<![\s\S]*?--[ \t\n\r]*>@'       // Strip multi-line comments
         );
-                
+
         $string = \preg_replace($patterns, '', $string);
         $string = \trim($string);
         $string = \stripslashes($string);
-        
+
         return \htmlentities($string);
     }
 
     /**
      * Creates self signed certificate
-     * 
+     *
      * @param string $privatekeyFile
      * @param string $certificateFile
      * @param string $signingFile
      * // param string $caCertificate
      * @param string $ssl_path
-     * @param array $details - certificate details 
-     * 
-     * Example: 
+     * @param array $details - certificate details
+     *
+     * Example:
      *  array $details = [
      *      "countryName" =>  '',
      *      "stateOrProvinceName" => '',
@@ -58,42 +58,42 @@ class ezQuery implements ezQueryInterface
      *      "commonName" => '',
      *      "emailAddress" => ''
      *  ];
-     * 
+     *
      * @return string certificate path
      */
     public static function createCertificate(
-        string $privatekeyFile = 'certificate.key', 
-        string $certificateFile = 'certificate.crt', 
-        string $signingFile = 'certificate.csr', 
-        // string $caCertificate = null, 
-        string $ssl_path = null, 
+        string $privatekeyFile = 'certificate.key',
+        string $certificateFile = 'certificate.crt',
+        string $signingFile = 'certificate.csr',
+        // string $caCertificate = null,
+        string $ssl_path = null,
         array $details = ["commonName" => "localhost"]
-    ) 
+    )
     {
         if (empty($ssl_path)) {
             $ssl_path = \getcwd();
             $ssl_path = \preg_replace('/\\\/', \_DS, $ssl_path). \_DS;
         } else
             $ssl_path = $ssl_path. \_DS;
-        
+
         $opensslConfig = array("config" => $ssl_path.'openssl.cnf');
-        
+
         // Generate a new private (and public) key pair
         $privatekey = \openssl_pkey_new($opensslConfig);
-            
+
         // Generate a certificate signing request
         $csr = \openssl_csr_new($details, $privatekey, $opensslConfig);
-    
+
         // Create a self-signed certificate valid for 365 days
         $sslcert = \openssl_csr_sign($csr, null, $privatekey, 365, $opensslConfig);
-    
+
         // Create key file. Note no passphrase
         \openssl_pkey_export_to_file($privatekey, $ssl_path.$privatekeyFile, null, $opensslConfig);
-    
-        // Create server certificate 
+
+        // Create server certificate
         \openssl_x509_export_to_file($sslcert, $ssl_path.$certificateFile, false);
-        
-        // Create a signing request file 
+
+        // Create a signing request file
         \openssl_csr_export_to_file($csr, $ssl_path.$signingFile);
 
         return $ssl_path;
@@ -101,38 +101,38 @@ class ezQuery implements ezQueryInterface
 
     /**
     * Return status of prepare function availability in shortcut method calls
-    */    
-    protected function isPrepareOn() 
+    */
+    protected function isPrepareOn()
     {
         return $this->prepareActive;
 	}
-  	
+
     /**
-     * Returns array of parameter values for prepare function 
+     * Returns array of parameter values for prepare function
      * @return array
-     */    
-    protected function prepareValues() 
+     */
+    protected function prepareValues()
     {
 		return $this->preparedValues;
 	}
-           
+
     /**
     * Add values to array variable for prepare function.
     * @param mixed $value
     *
     * @return int array count
     */
-    protected function addPrepare($value = null) 
+    protected function addPrepare($value = null)
     {
-        return \array_push($this->preparedValues, $value); 
+        return \array_push($this->preparedValues, $value);
     }
-    
+
     /**
     * Clear out prepare parameter values
     *
     * @return bool false
     */
-    protected function clearPrepare() 
+    protected function clearPrepare()
     {
         $this->preparedValues = array();
         return false;
@@ -142,7 +142,7 @@ class ezQuery implements ezQueryInterface
     {
         $this->prepareActive = true;
     }
-    
+
     public function prepareOff()
     {
         $this->prepareActive = $this->clearPrepare();
@@ -152,9 +152,9 @@ class ezQuery implements ezQueryInterface
     * Convert array to string, and attach '`, `' for separation, if none is provided.
     *
     * @return string
-    */  
-    public static function to_string($arrays, $separation = ',')  
-    {        
+    */
+    public static function to_string($arrays, $separation = ',')
+    {
         if (\is_array( $arrays )) {
             $columns = '';
             foreach($arrays as $val) {
@@ -171,9 +171,9 @@ class ezQuery implements ezQueryInterface
         if (empty($groupBy)) {
             return false;
         }
-        
+
         $columns = $this->to_string($groupBy);
-        
+
         return 'GROUP BY ' .$columns;
     }
 
@@ -184,8 +184,8 @@ class ezQuery implements ezQueryInterface
     }
 
     public function innerJoin(
-        string $leftTable = null, 
-        string $rightTable = null, 
+        string $leftTable = null,
+        string $rightTable = null,
         string $leftColumn = null, string $rightColumn = null, $condition = \EQ)
     {
         return $this->joining(
@@ -193,8 +193,8 @@ class ezQuery implements ezQueryInterface
     }
 
     public function leftJoin(
-        string $leftTable = null, 
-        string $rightTable = null, 
+        string $leftTable = null,
+        string $rightTable = null,
         string $leftColumn = null, string $rightColumn = null, $condition = \EQ)
     {
         return $this->joining(
@@ -202,8 +202,8 @@ class ezQuery implements ezQueryInterface
     }
 
     public function rightJoin(
-        string $leftTable = null, 
-        string $rightTable = null, 
+        string $leftTable = null,
+        string $rightTable = null,
         string $leftColumn = null, string $rightColumn = null, $condition = \EQ)
     {
         return $this->joining(
@@ -211,8 +211,8 @@ class ezQuery implements ezQueryInterface
     }
 
     public function fullJoin(
-        string $leftTable = null, 
-        string $rightTable = null, 
+        string $leftTable = null,
+        string $rightTable = null,
         string $leftColumn = null, string $rightColumn = null, $condition = \EQ)
     {
         return $this->joining(
@@ -222,48 +222,48 @@ class ezQuery implements ezQueryInterface
     /**
     * For multiple select joins, combine rows from tables where `on` condition is met
     *
-    * - Will perform an equal on tables by left column key, 
-    *       left column key and left table, left column key and right table, 
+    * - Will perform an equal on tables by left column key,
+    *       left column key and left table, left column key and right table,
     *           if `rightColumn` is null.
     *
-    * - Will perform an equal on tables by, 
-    *       left column key and left table, right column key and right table, 
+    * - Will perform an equal on tables by,
+    *       left column key and left table, right column key and right table,
     *           if `rightColumn` not null, and `$condition` not changed.
     *
     * - Will perform the `condition` on passed in arguments, for left column, and right column.
     *           if `$condition`,  is in the array
     *
     * @param string $type - Either `INNER`, `LEFT`, `RIGHT`, `FULL`
-    * @param string $leftTable - 
-    * @param string $rightTable - 
+    * @param string $leftTable -
+    * @param string $rightTable -
     *
-    * @param string $leftColumn - 
-    * @param string $rightColumn - 
+    * @param string $leftColumn -
+    * @param string $rightColumn -
     *
-    * @param string $condition -  
+    * @param string $condition -
     *
     * @return bool|string JOIN sql statement, false for error
     */
     private function joining(
         String $type = \_INNER,
-        string $leftTable = null, 
-        string $rightTable = null, 
-        string $leftColumn = null, string $rightColumn = null, $condition = \EQ) 
+        string $leftTable = null,
+        string $rightTable = null,
+        string $leftColumn = null, string $rightColumn = null, $condition = \EQ)
     {
-        if (!\in_array($type, \_JOINERS) 
-            || !\in_array($condition, \_BOOLEAN) 
-            || empty($leftTable) 
-            || empty($rightTable) || empty($columnFields) || empty($leftColumn)
+        if (!\in_array($type, \_JOINERS)
+            || !\in_array($condition, \_BOOLEAN)
+            || empty($leftTable)
+            || empty($rightTable) || empty($leftColumn)
         ) {
             return false;
         }
 
         if (\is_string($leftColumn) && empty($rightColumn))
-            $onCondition = ' ON '.$leftTable.$leftColumn.' = '.$rightTable.$leftColumn;
+            $onCondition = ' ON '.$leftTable.'.'.$leftColumn.' = '.$rightTable.'.'.$leftColumn;
         elseif ($condition !== \EQ)
-            $onCondition = ' ON '.$leftTable.$leftColumn." $condition ".$rightTable.$rightColumn;
+            $onCondition = ' ON '.$leftTable.'.'.$leftColumn." $condition ".$rightTable.'.'.$rightColumn;
         else
-            $onCondition = ' ON '.$leftTable.$leftColumn.' = '.$rightTable.$rightColumn;
+            $onCondition = ' ON '.$leftTable.'.'.$leftColumn.' = '.$rightTable.'.'.$rightColumn;
 
         return ' '.$type.' JOIN '.$rightTable.$onCondition;
     }
@@ -273,11 +273,11 @@ class ezQuery implements ezQueryInterface
         if (empty($orderBy)) {
             return false;
         }
-        
+
         $columns = $this->to_string($orderBy);
-        
+
         $order = (\in_array(\strtoupper($order), array( 'ASC', 'DESC'))) ? \strtoupper($order) : 'ASC';
-        
+
         return 'ORDER BY '.$columns.' '. $order;
     }
 
@@ -286,61 +286,61 @@ class ezQuery implements ezQueryInterface
         if (empty($numberOf)) {
             return false;
         }
-        
+
         $rows = (int) $numberOf;
-        
+
         $value = !empty($offset) ? ' OFFSET '.(int) $offset : '';
-        
+
         return 'LIMIT '.$rows.$value;
     }
 
-    private function conditions($key, $condition, $value, $combine) 
-    {        
+    private function conditions($key, $condition, $value, $combine)
+    {
         if ($this->isPrepareOn()) {
             $this->whereSQL .= "$key $condition ".\_TAG." $combine ";
             $this->addPrepare($value);
-        } else 
+        } else
             $this->whereSQL .= "$key $condition '".$this->escape($value)."' $combine ";
     }
 
-    private function conditionBetween($key, $condition, $valueOne, $valueTwo, $combine) 
+    private function conditionBetween($key, $condition, $valueOne, $valueTwo, $combine)
     {
         $_valueTwo = $this->escape($valueTwo);
         $andCombineWith = \_AND;
-        if (\in_array(\strtoupper($combine), \_COMBINERS)) 
+        if (\in_array(\strtoupper($combine), \_COMBINERS))
             $andCombineWith = \strtoupper($combine);
 
         if ($this->isPrepareOn()) {
             $this->whereSQL .= "$key ".$condition.' '.\_TAG." AND ".\_TAG." $andCombineWith ";
             $this->addPrepare($valueOne);
             $this->addPrepare($valueTwo);
-        } else 
+        } else
             $this->whereSQL .= "$key $condition '".$this->escape($valueOne)."' AND '".$_valueTwo."' $andCombineWith ";
-        
+
 		$this->combineWith = $andCombineWith;
     }
 
-    private function conditionIn($key, $condition, $valueRow, $combine) 
+    private function conditionIn($key, $condition, $valueRow, $combine)
     {
         $value = '';
         foreach ($valueRow as $splitValue) {
             if ($this->isPrepareOn()) {
                 $value .= \_TAG.', ';
                 $this->addPrepare($splitValue);
-            } else 
+            } else
                 $value .= "'".$this->escape($splitValue)."', ";
         }
-        
+
         $this->whereSQL .= "$key $condition ( ".\rtrim($value, ', ')." ) $combine ";
     }
 
-    private function conditionIs($key, $condition, $combine) 
-    {        
+    private function conditionIs($key, $condition, $combine)
+    {
         $isCondition = (($condition == 'IS') || ($condition == 'IS NOT')) ? $condition : 'IS';
         $this->whereSQL .= "$key $isCondition NULL $combine ";
     }
 
-    private function retrieveConditions($whereConditions) 
+    private function retrieveConditions($whereConditions)
     {
         $whereClause = [];
         $operator = [];
@@ -361,13 +361,13 @@ class ezQuery implements ezQueryInterface
 				$whereClause[ (isset($checkFields[0])) ? $checkFields[0] : '1' ] = (isset($checkFields[2])) ? $checkFields[2] : '' ;
 				$combiner[] = (isset($checkFields[3])) ? $checkFields[3]: \_AND;
 				$extra[] = (isset($checkFields[4])) ? $checkFields[4]: null;
-			}           
+			}
         }
 
         return [$operator, $whereClause, $combiner, $extra];
     }
 
-    private function processConditions($column, $condition, $value, $valueOrCombine, $extraCombine) 
+    private function processConditions($column, $condition, $value, $valueOrCombine, $extraCombine)
     {
         if (! \in_array( $condition, \_BOOLEAN_OPERATORS))
             return $this->clearPrepare();
@@ -385,7 +385,7 @@ class ezQuery implements ezQueryInterface
         }
     }
 
-    public function where( ...$whereConditions) 
+    public function where( ...$whereConditions)
     {
         if (empty($whereConditions))
 			return false;
@@ -394,15 +394,15 @@ class ezQuery implements ezQueryInterface
         $this->isWhere = true;
 
         $this->combineWith = '';
-        
+
         if (\is_string($whereConditions[0]) && \strpos($whereConditions[0],  $whereOrHaving) !== false)
             return $whereConditions[0];
-        
+
         list($operator, $whereClause, $combiner, $extra) = $this->retrieveConditions($whereConditions);
         if (empty($operator))
             return false;
 
-        $where = '1';    
+        $where = '1';
         if (! isset($whereClause['1'])) {
             $this->whereSQL = '';
             $i = 0;
@@ -410,10 +410,10 @@ class ezQuery implements ezQueryInterface
                 $isCondition = \strtoupper($operator[$i]);
 				$combine = $combiner[$i];
                 $this->combineWith = \_AND;
-				if ( \in_array(\strtoupper($combine), \_COMBINERS) || isset($extra[$i]))                  
+				if ( \in_array(\strtoupper($combine), \_COMBINERS) || isset($extra[$i]))
                     $this->combineWith = isset($extra[$i]) ? $combine : \strtoupper($combine);
 
-                if ($this->processConditions($key, $isCondition, $val,  $this->combineWith, $extra[$i]) === false) 
+                if ($this->processConditions($key, $isCondition, $val,  $this->combineWith, $extra[$i]) === false)
                     return false;
 
                 $i++;
@@ -422,48 +422,48 @@ class ezQuery implements ezQueryInterface
             $where = \rtrim($this->whereSQL, " $this->combineWith ");
             $this->whereSQL = null;
         }
-		
+
         if (($this->isPrepareOn()) && !empty($this->prepareValues()) && ($where != '1'))
 			return " $whereOrHaving $where ";
-        
+
 		return ($where != '1') ? " $whereOrHaving $where " : ' ';
-    }        
-    
-    public function selecting(string $table = null, $columnFields = '*', ...$conditions) 
-    {    
+    }
+
+    public function selecting(string $table = null, $columnFields = '*', ...$conditions)
+    {
 		$getFromTable = $this->fromTable;
-		$getSelect_result = $this->select_result;       
+		$getSelect_result = $this->select_result;
 		$getIsInto = $this->isInto;
-        
+
 		$this->fromTable = null;
-		$this->select_result = true;	
-		$this->isInto = false;	
-        
+		$this->select_result = true;
+		$this->isInto = false;
+
         $skipWhere = false;
         $whereKeys = $conditions;
         $where = '';
-		
+
         if (empty($table)) {
             return $this->clearPrepare();
         }
-        
+
         $columns = $this->to_string($columnFields);
-        
-		if (isset($getFromTable) && ! $getIsInto) 
+
+		if (isset($getFromTable) && ! $getIsInto)
 			$sql="CREATE TABLE $table AS SELECT $columns FROM ".$getFromTable;
-        elseif (isset($getFromTable) && $getIsInto) 
+        elseif (isset($getFromTable) && $getIsInto)
 			$sql="SELECT $columns INTO $table FROM ".$getFromTable;
-        else 
+        else
 			$sql="SELECT $columns FROM ".$table;
 
         if (!empty($conditions)) {
 			if (\is_string($conditions[0])) {
                 $args_by = '';
-                $joinSet = false;      
-                $groupBySet = false;      
-                $havingSet = false;             
-                $orderBySet = false;   
-                $limitSet = false;     
+                $joinSet = false;
+                $groupBySet = false;
+                $havingSet = false;
+                $orderBySet = false;
+                $limitSet = false;
                 $unionSet = false;
 				foreach ($conditions as $checkFor) {
                     if (\strpos($checkFor, 'JOIN') !== false ) {
@@ -483,13 +483,13 @@ class ezQuery implements ezQueryInterface
                             return $this->clearPrepare();
                         }
                     } elseif (\strpos($checkFor, 'ORDER BY') !== false ) {
-                        $args_by .= ' '.$checkFor;    
+                        $args_by .= ' '.$checkFor;
                         $orderBySet = true;
                     } elseif (\strpos($checkFor, 'LIMIT') !== false ) {
-                        $args_by .= ' '.$checkFor;    
+                        $args_by .= ' '.$checkFor;
                         $limitSet = true;
                     } elseif (\strpos($checkFor, 'UNION') !== false ) {
-                        $args_by .= ' '.$checkFor;    
+                        $args_by .= ' '.$checkFor;
                         $unionSet = true;
                     }
                 }
@@ -498,23 +498,23 @@ class ezQuery implements ezQueryInterface
                     $where = $args_by;
                     $skipWhere = true;
                 }
-			}		
+			}
 		} else {
             $skipWhere = true;
-        }        
-        
+        }
+
         if (! $skipWhere)
             $where = $this->where( ...$whereKeys);
-        
+
         if (\is_string($where)) {
             $sql .= $where;
-            if ($getSelect_result) 
-                return (($this->isPrepareOn()) && !empty($this->prepareValues())) 
-                    ? $this->get_results($sql, \OBJECT, true) 
-                    : $this->get_results($sql);     
+            if ($getSelect_result)
+                return (($this->isPrepareOn()) && !empty($this->prepareValues()))
+                    ? $this->get_results($sql, \OBJECT, true)
+                    : $this->get_results($sql);
             return $sql;
         }
-        
+
         return $this->clearPrepare();
     }
 
@@ -525,61 +525,61 @@ class ezQuery implements ezQueryInterface
     private function select_sql($table = '', $columnFields = '*', ...$conditions)
     {
 		$this->select_result = false;
-        return $this->selecting($table, $columnFields, ...$conditions);	            
+        return $this->selecting($table, $columnFields, ...$conditions);
     }
 
     public function union(string $table = null, $columnFields = '*', ...$conditions)
     {
-        return 'UNION '.$this->select_sql($table, $columnFields, ...$conditions);           
+        return 'UNION '.$this->select_sql($table, $columnFields, ...$conditions);
     }
 
     public function unionAll(string $table = null, $columnFields = '*', ...$conditions)
     {
-        return 'UNION ALL '.$this->select_sql($table, $columnFields, ...$conditions);             
+        return 'UNION ALL '.$this->select_sql($table, $columnFields, ...$conditions);
     }
 
-    public function create_select(string $newTable, $fromColumns, $oldTable = null, ...$conditions) 
+    public function create_select(string $newTable, $fromColumns, $oldTable = null, ...$conditions)
     {
 		if (isset($oldTable))
 			$this->fromTable = $oldTable;
 		else {
-            return $this->clearPrepare();            
+            return $this->clearPrepare();
         }
-			
-        $newTableFromTable = $this->select_sql($newTable, $fromColumns, ...$conditions);			
-        if (is_string($newTableFromTable))
-            return (($this->isPrepareOn()) && !empty($this->prepareValues())) 
-                ? $this->query($newTableFromTable, true) 
-                : $this->query($newTableFromTable); 
 
-        return $this->clearPrepare();   
+        $newTableFromTable = $this->select_sql($newTable, $fromColumns, ...$conditions);
+        if (is_string($newTableFromTable))
+            return (($this->isPrepareOn()) && !empty($this->prepareValues()))
+                ? $this->query($newTableFromTable, true)
+                : $this->query($newTableFromTable);
+
+        return $this->clearPrepare();
     }
-    
-    public function select_into(string $newTable, $fromColumns, $oldTable = null, ...$conditions) 
+
+    public function select_into(string $newTable, $fromColumns, $oldTable = null, ...$conditions)
     {
-		$this->isInto = true;        
+		$this->isInto = true;
 		if (isset($oldTable))
 			$this->fromTable = $oldTable;
 		else
 			return $this->clearPrepare();
-			
+
         $newTableFromTable = $this->select_sql($newTable, $fromColumns, ...$conditions);
         if (is_string($newTableFromTable))
-            return (($this->isPrepareOn()) && !empty($this->prepareValues())) 
-                ? $this->query($newTableFromTable, true) 
-                : $this->query($newTableFromTable); 
-        
-        return $this->clearPrepare();     
+            return (($this->isPrepareOn()) && !empty($this->prepareValues()))
+                ? $this->query($newTableFromTable, true)
+                : $this->query($newTableFromTable);
+
+        return $this->clearPrepare();
     }
 
-    public function update(string $table = null, $keyAndValue, ...$whereConditions) 
-    {        
+    public function update(string $table = null, $keyAndValue, ...$whereConditions)
+    {
         if ( ! is_array( $keyAndValue ) || empty($table) ) {
 			return $this->clearPrepare();
         }
-        
+
         $sql = "UPDATE $table SET ";
-        
+
         foreach($keyAndValue as $key => $val) {
             if(\strtolower($val)=='null') {
 				$sql .= "$key = NULL, ";
@@ -589,82 +589,82 @@ class ezQuery implements ezQueryInterface
 				if ($this->isPrepareOn()) {
 					$sql .= "$key = ".\_TAG.", ";
 					$this->addPrepare($val);
-				} else 
+				} else
 					$sql .= "$key = '".$this->escape($val)."', ";
 			}
         }
-        
+
         $where = $this->where(...$whereConditions);
-        if (\is_string($where)) {   
+        if (\is_string($where)) {
             $sql = \rtrim($sql, ', ') . $where;
-            return (($this->isPrepareOn()) && !empty($this->prepareValues())) 
-                ? $this->query($sql, true) 
-                : $this->query($sql) ;       
-        } 
-        
-        return $this->clearPrepare();
-    }   
-         
-    public function delete(string $table = null, ...$whereConditions) 
-    {   
-        if ( empty($table) ) {
-			return $this->clearPrepare();         			
-		}  
-		
-        $sql = "DELETE FROM $table";
-        
-        $where = $this->where(...$whereConditions);
-        if (\is_string($where)) {   
-            $sql .= $where;						
-            return (($this->isPrepareOn()) && !empty($this->prepareValues())) 
-                ? $this->query($sql, true) 
-                : $this->query($sql);  
+            return (($this->isPrepareOn()) && !empty($this->prepareValues()))
+                ? $this->query($sql, true)
+                : $this->query($sql) ;
         }
 
-        return $this->clearPrepare();       
+        return $this->clearPrepare();
+    }
+
+    public function delete(string $table = null, ...$whereConditions)
+    {
+        if ( empty($table) ) {
+			return $this->clearPrepare();
+		}
+
+        $sql = "DELETE FROM $table";
+
+        $where = $this->where(...$whereConditions);
+        if (\is_string($where)) {
+            $sql .= $where;
+            return (($this->isPrepareOn()) && !empty($this->prepareValues()))
+                ? $this->query($sql, true)
+                : $this->query($sql);
+        }
+
+        return $this->clearPrepare();
     }
 
 	/**
     * Helper does the actual insert or replace query with an array
 	* @return mixed bool/results - false for error
 	*/
-    private function _query_insert_replace($table = '', $keyAndValue, $type = '', $execute = true) 
-    {  
+    private function _query_insert_replace($table = '', $keyAndValue, $type = '', $execute = true)
+    {
         if ((! \is_array($keyAndValue) && ($execute)) || empty($table)) {
-			return $this->clearPrepare();          			
-		}  
-        
+			return $this->clearPrepare();
+		}
+
         if ( ! \in_array( strtoupper( $type ), array( 'REPLACE', 'INSERT' ))) {
-			return $this->clearPrepare();          			
-		}  
-            
+			return $this->clearPrepare();
+		}
+
         $sql = "$type INTO $table";
-        $value = ''; 
+        $value = '';
         $index = '';
 
         if ($execute) {
             foreach($keyAndValue as $key => $val) {
                 $index .= "$key, ";
-                if (\strtolower($val) == 'null') 
+                if (\strtolower($val) == 'null')
                     $value .= "NULL, ";
-                elseif (\in_array(\strtolower($val), array( 'current_timestamp()', 'date()', 'now()' ))) 
+                elseif (\in_array(\strtolower($val), array( 'current_timestamp()', 'date()', 'now()' )))
                     $value .= "CURRENT_TIMESTAMP(), ";
                 else {
 					if ($this->isPrepareOn()) {
 						$value .= _TAG.", ";
 						$this->addPrepare($val);
-					} else 
+					} else
 						$value .= "'".$this->escape($val)."', ";
-				}               
+				}
             }
-            
+
             $sql .= "(". \rtrim($index, ', ') .") VALUES (". \rtrim($value, ', ') .");";
 
-			if (($this->isPrepareOn()) && !empty($this->prepareValues())) 
+			if (($this->isPrepareOn()) && !empty($this->prepareValues()))
 				$ok = $this->query($sql, true);
-			else 
+			else
 				$ok = $this->query($sql);
-				
+
             if ($ok)
                 return $this->insert_id;
 
@@ -673,60 +673,60 @@ class ezQuery implements ezQueryInterface
             if (\is_array($keyAndValue)) {
                 if (\array_keys($keyAndValue) === \range(0, \count($keyAndValue) - 1)) {
                     foreach($keyAndValue as $key) {
-                        $index .= "$key, ";                
+                        $index .= "$key, ";
                     }
-                    $sql .= " (". \rtrim($index, ', ') .") ";                         
+                    $sql .= " (". \rtrim($index, ', ') .") ";
                 } else {
-					return false;          			
-				}          
-            } 
+					return false;
+				}
+            }
 
             return $sql;
         }
 	}
-        
-    public function replace(string $table = null, $keyAndValue) 
+
+    public function replace(string $table = null, $keyAndValue)
     {
         return $this->_query_insert_replace($table, $keyAndValue, 'REPLACE');
     }
 
-    public function insert(string $table = null, $keyAndValue) 
+    public function insert(string $table = null, $keyAndValue)
     {
         return $this->_query_insert_replace($table, $keyAndValue, 'INSERT');
     }
 
-    public function insert_select(string $toTable = null, $toColumns = '*', $fromTable = null, $fromColumns = '*', ...$conditions) 
+    public function insert_select(string $toTable = null, $toColumns = '*', $fromTable = null, $fromColumns = '*', ...$conditions)
     {
         $putToTable = $this->_query_insert_replace($toTable, $toColumns, 'INSERT', false);
         $getFromTable = $this->select_sql($fromTable, $fromColumns, ...$conditions);
 
         if (\is_string($putToTable) && \is_string($getFromTable))
-            return (($this->isPrepareOn()) && !empty($this->prepareValues())) 
-                ? $this->query($putToTable." ".$getFromTable, true) 
+            return (($this->isPrepareOn()) && !empty($this->prepareValues()))
+                ? $this->query($putToTable." ".$getFromTable, true)
                 : $this->query($putToTable." ".$getFromTable) ;
 
-		return $this->clearPrepare();      
+		return $this->clearPrepare();
     }
 
     // get_results call template
-	public function get_results(string $query = null, $output = \OBJECT, 
-		bool $use_prepare = false) 
+	public function get_results(string $query = null, $output = \OBJECT,
+		bool $use_prepare = false)
 	{
 		return array();
     }
 
 	// query call template
-	public function query(string $query, bool $use_prepare = false) 
+	public function query(string $query, bool $use_prepare = false)
 	{
 		return false;
-    }    
+    }
 
 	// escape call template if not available by vendor
-	public function escape(string $str) 
+	public function escape(string $str)
 	{
-		if (empty($str) ) 
+		if (empty($str) )
 			return '';
-		if ( \is_numeric($str) ) 
+		if ( \is_numeric($str) )
 			return $str;
 
         $nonDisplayable = array(
@@ -737,7 +737,7 @@ class ezQuery implements ezQueryInterface
 			'/\x0c/',                   // 12
 			'/[\x0e-\x1f]/'             // 14-31
 		);
-                
+
         foreach ( $nonDisplayable as $regex )
 			$str = \preg_replace( $regex, '', $str);
 
@@ -746,14 +746,14 @@ class ezQuery implements ezQueryInterface
 
         return \str_replace($search, $replace, $str);
     }
-    
+
     /**
      * Creates an database schema from array
      *  - column, datatype, value/options/key arguments.
-     * 
+     *
      * @return string|bool - SQL schema string, or false for error
      */
-   private function create_schema(array ...$columnDataOptions) 
+   private function create_schema(array ...$columnDataOptions)
    {
         if (empty($columnDataOptions))
            return false;
@@ -773,7 +773,7 @@ class ezQuery implements ezQueryInterface
        return false;
    }
 
-   public function create(string $table = null, ...$schemas) 
+   public function create(string $table = null, ...$schemas)
    {
         $vendor = ezSchema::vendor();
         if (empty($table) || empty($schemas) || empty($vendor))
@@ -783,7 +783,7 @@ class ezQuery implements ezQueryInterface
 
         $skipSchema = false;
         if (\is_string($schemas[0])) {
-            $data = '';            
+            $data = '';
             $stringTypes = ezSchema::STRINGS['common'];
             $stringTypes += ezSchema::STRINGS[$vendor];
             $numericTypes = ezSchema::NUMERICS['common'];
@@ -799,9 +799,9 @@ class ezQuery implements ezQueryInterface
             $numericPattern = "/".\implode('|', $numericTypes)."/i";
             $numberPattern = "/".\implode('|', $numberTypes)."/i";
             $dateTimePattern = "/".\implode('|', $dateTimeTypes)."/i";
-            $objectPattern = "/".\implode('|', $objectTypes)."/i";        
+            $objectPattern = "/".\implode('|', $objectTypes)."/i";
             $patternOther = "/".\implode('|', $allowedTypes)."/i";
-            foreach($schemas as $types) {                
+            foreach($schemas as $types) {
                 if (\preg_match($stringPattern, $types)) {
                     $data .= $types;
                     $skipSchema = true;
@@ -837,7 +837,7 @@ class ezQuery implements ezQueryInterface
    }
 
    // todo not finish, not tested
-   public function alter(string $table = null, ...$schemas) 
+   public function alter(string $table = null, ...$schemas)
    {
         if (empty($table) || empty($schemas))
            return false;
@@ -868,7 +868,7 @@ class ezQuery implements ezQueryInterface
         return false;
    }
 
-   public function drop(string $table = null) 
+   public function drop(string $table = null)
    {
         if (empty($table))
            return false;

--- a/lib/ezQuery.php
+++ b/lib/ezQuery.php
@@ -267,11 +267,11 @@ class ezQuery implements ezQueryInterface
             $tableAs = $rightTable;
 
         if (\is_string($leftColumn) && empty($rightColumn))
-            $onCondition = ' ON '.$leftTable.'.'.$leftColumn.' = '.$rightTable.'.'.$leftColumn;
+            $onCondition = ' ON '.$leftTable.'.'.$leftColumn.' = '.$tableAs.'.'.$leftColumn;
         elseif ($condition !== \EQ)
-            $onCondition = ' ON '.$leftTable.'.'.$leftColumn." $condition ".$rightTable.'.'.$rightColumn;
+            $onCondition = ' ON '.$leftTable.'.'.$leftColumn." $condition ".$tableAs.'.'.$rightColumn;
         else
-            $onCondition = ' ON '.$leftTable.'.'.$leftColumn.' = '.$rightTable.'.'.$rightColumn;
+            $onCondition = ' ON '.$leftTable.'.'.$leftColumn.' = '.$tableAs.'.'.$rightColumn;
 
         return ' '.$type.' JOIN '.$rightTable.' AS '.$tableAs.' '.$onCondition;
     }

--- a/lib/ezQuery.php
+++ b/lib/ezQuery.php
@@ -186,37 +186,41 @@ class ezQuery implements ezQueryInterface
     public function innerJoin(
         string $leftTable = null,
         string $rightTable = null,
-        string $leftColumn = null, string $rightColumn = null, $condition = \EQ)
+        string $leftColumn = null, string $rightColumn = null,
+        string $tableAs = null, $condition = \EQ)
     {
         return $this->joining(
-            'INNER', $leftTable, $rightTable, $leftColumn, $rightColumn, $condition);
+            'INNER', $leftTable, $rightTable, $leftColumn, $rightColumn, $tableAs, $condition);
     }
 
     public function leftJoin(
         string $leftTable = null,
         string $rightTable = null,
-        string $leftColumn = null, string $rightColumn = null, $condition = \EQ)
+        string $leftColumn = null, string $rightColumn = null,
+        string $tableAs = null, $condition = \EQ)
     {
         return $this->joining(
-            'LEFT', $leftTable, $rightTable, $leftColumn, $rightColumn, $condition);
+            'LEFT', $leftTable, $rightTable, $leftColumn, $rightColumn, $tableAs, $condition);
     }
 
     public function rightJoin(
         string $leftTable = null,
         string $rightTable = null,
-        string $leftColumn = null, string $rightColumn = null, $condition = \EQ)
+        string $leftColumn = null, string $rightColumn = null,
+        string $tableAs = null, $condition = \EQ)
     {
         return $this->joining(
-            'RIGHT', $leftTable, $rightTable, $leftColumn, $rightColumn, $condition);
+            'RIGHT', $leftTable, $rightTable, $leftColumn, $rightColumn, $tableAs, $condition);
     }
 
     public function fullJoin(
         string $leftTable = null,
         string $rightTable = null,
-        string $leftColumn = null, string $rightColumn = null, $condition = \EQ)
+        string $leftColumn = null, string $rightColumn = null,
+        string $tableAs = null, $condition = \EQ)
     {
         return $this->joining(
-            'FULL', $leftTable, $rightTable, $$leftColumn, $rightColumn, $condition);
+            'FULL', $leftTable, $rightTable, $$leftColumn, $rightColumn, $tableAs, $condition);
     }
 
     /**
@@ -248,7 +252,8 @@ class ezQuery implements ezQueryInterface
         String $type = \_INNER,
         string $leftTable = null,
         string $rightTable = null,
-        string $leftColumn = null, string $rightColumn = null, $condition = \EQ)
+        string $leftColumn = null, string $rightColumn = null,
+        string $tableAs = null, $condition = \EQ)
     {
         if (!\in_array($type, \_JOINERS)
             || !\in_array($condition, \_BOOLEAN)
@@ -258,6 +263,9 @@ class ezQuery implements ezQueryInterface
             return false;
         }
 
+        if (empty($tableAs))
+            $tableAs = $rightTable;
+
         if (\is_string($leftColumn) && empty($rightColumn))
             $onCondition = ' ON '.$leftTable.'.'.$leftColumn.' = '.$rightTable.'.'.$leftColumn;
         elseif ($condition !== \EQ)
@@ -265,7 +273,7 @@ class ezQuery implements ezQueryInterface
         else
             $onCondition = ' ON '.$leftTable.'.'.$leftColumn.' = '.$rightTable.'.'.$rightColumn;
 
-        return ' '.$type.' JOIN '.$rightTable.$onCondition;
+        return ' '.$type.' JOIN '.$rightTable.' AS '.$tableAs.' '.$onCondition;
     }
 
     public function orderBy($orderBy, $order)

--- a/lib/ezQuery.php
+++ b/lib/ezQuery.php
@@ -206,8 +206,8 @@ class ezQuery implements ezQueryInterface
         string $leftColumn = null,
         string $rightColumn = null,
         string $tableAs = null,
-        $condition = \EQ)
-    {
+        $condition = \EQ
+    ) {
         return $this->joining(
             'LEFT',
             $leftTable,
@@ -258,29 +258,30 @@ class ezQuery implements ezQueryInterface
     }
 
     /**
-    * For multiple select joins, combine rows from tables where `on` condition is met
-    *
-    * - Will perform an equal on tables by left column key,
-    *       left column key and left table, left column key and right table,
-    *           if `rightColumn` is null.
-    *
-    * - Will perform an equal on tables by,
-    *       left column key and left table, right column key and right table,
-    *           if `rightColumn` not null, and `$condition` not changed.
-    *
-    * - Will perform the `condition` on passed in arguments, for left column, and right column.
-    *           if `$condition`,  is in the array
-    *
-    * @param string $type - Either `INNER`, `LEFT`, `RIGHT`, `FULL`
-    * @param string $leftTable -
-    * @param string $rightTable -
-    *
-    * @param string $leftColumn -
-    * @param string $rightColumn -
-    *
-    * @param string $condition -
-    *
-    * @return bool|string JOIN sql statement, false for error
+     * For multiple select joins, combine rows from tables where `on` condition is met
+     *
+     * - Will perform an equal on tables by left column key,
+     *       left column key and left table, left column key and right table,
+     *           if `rightColumn` is null.
+     *
+     * - Will perform an equal on tables by,
+     *       left column key and left table, right column key and right table,
+     *           if `rightColumn` not null, and `$condition` not changed.
+     *
+     * - Will perform the `condition` on passed in arguments, for left column, and right column.
+     *           if `$condition`,  is in the array
+     *
+     * @param string $type - Either `INNER`, `LEFT`, `RIGHT`, `FULL`
+     * @param string $leftTable -
+     * @param string $rightTable -
+     *
+     * @param string $leftColumn -
+     * @param string $rightColumn -
+     * @param string $tableAs -
+     *
+     * @param string $condition -
+     *
+     * @return bool|string JOIN sql statement, false for error
     */
     private function joining(
         String $type = \_INNER,
@@ -291,10 +292,12 @@ class ezQuery implements ezQueryInterface
         string $tableAs = null,
         $condition = \EQ
     ) {
-        if (!\in_array($type, \_JOINERS)
+        if (
+            !\in_array($type, \_JOINERS)
             || !\in_array($condition, \_BOOLEAN)
             || empty($leftTable)
-            || empty($rightTable) || empty($leftColumn)
+            || empty($rightTable)
+            || empty($leftColumn)
         ) {
             return false;
         }
@@ -303,13 +306,13 @@ class ezQuery implements ezQueryInterface
             $tableAs = $rightTable;
 
         if (\is_string($leftColumn) && empty($rightColumn))
-            $onCondition = ' ON '.$leftTable.'.'.$leftColumn.' = '.$tableAs.'.'.$leftColumn;
+            $onCondition = ' ON ' . $leftTable . '.' . $leftColumn . ' ' . $condition . ' ' . $tableAs . '.' . $leftColumn;
         elseif ($condition !== \EQ)
-            $onCondition = ' ON '.$leftTable.'.'.$leftColumn." $condition ".$tableAs.'.'.$rightColumn;
+            $onCondition = ' ON ' . $leftTable . '.' . $leftColumn . ' ' . $condition . ' ' . $tableAs . '.' . $rightColumn;
         else
-            $onCondition = ' ON '.$leftTable.'.'.$leftColumn.' = '.$tableAs.'.'.$rightColumn;
+            $onCondition = ' ON ' . $leftTable . '.' . $leftColumn . ' ' . $condition . ' ' . $tableAs . '.' . $rightColumn;
 
-        return ' '.$type.' JOIN '.$rightTable.' AS '.$tableAs.' '.$onCondition;
+        return ' ' . $type . ' JOIN ' . $rightTable . ' AS ' . $tableAs . ' ' . $onCondition;
     }
 
     public function orderBy($orderBy, $order)

--- a/lib/ezQueryInterface.php
+++ b/lib/ezQueryInterface.php
@@ -7,7 +7,7 @@
  * Any errors will return an boolean false, and you will be responsible for handling.
  *
  * ezQuery does no validation whatsoever if certain features even work with the
- * underlying database vendor. 
+ * underlying database vendor.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
@@ -27,60 +27,60 @@
 namespace ezsql;
 
 interface ezQueryInterface
-{ 	
+{
     /**
     * Clean input of XSS, html, javascript, etc...
     * @param string $string
     * @return string cleaned string
-    */	        
+    */
     public static function clean($string);
-      	
+
     /**
-    * Turn on prepare function availability in ezQuery shortcut method calls 
+    * Turn on prepare function availability in ezQuery shortcut method calls
     */
     public function prepareOn();
-      	
+
     /**
-    * Turn off prepare function availability in ezQuery shortcut method calls 
+    * Turn off prepare function availability in ezQuery shortcut method calls
     */
     public function prepareOff();
-    
+
 
     /**
     * Specifies a grouping over the results of the query.
     *<code>
-    *   selecting('table', 
+    *   selecting('table',
     *       'columns',
     *        where( eq( 'columns', values, _AND ), like( 'columns', _d ) ),
     *        groupBy( 'columns' ),
     *        having( between( 'columns', values1, values2 ) ),
     *        orderBy( 'columns', 'desc' );
-    *</code>    
-    * @param mixed $groupBy The grouping expression.  
+    *</code>
+    * @param mixed $groupBy The grouping expression.
 	*
     * @return string - GROUP BY SQL statement, or false on error
     */
     public function groupBy($groupBy);
 
     /**
-    * Specifies a restriction over the groups of the query. 
+    * Specifies a restriction over the groups of the query.
     *
-    * format 
-    *   `having( array(x, =, y, and, extra) );` or 
+    * format
+    *   `having( array(x, =, y, and, extra) );` or
     *   `having( "x  =  y  and  extra" );`
     *
-    * example: 
-    *   `having( array(key, operator, value, combine, extra) );`or 
+    * example:
+    *   `having( array(key, operator, value, combine, extra) );`or
     *   `having( "key operator value combine extra" );`
     *
     * @param array $having
-    * @param string $key, - table column  
-    * @param string $operator, - set the operator condition, 
-    *                       either '<','>', '=', '!=', '>=', '<=', '<>', 'in', 
+    * @param string $key, - table column
+    * @param string $operator, - set the operator condition,
+    *                       either '<','>', '=', '!=', '>=', '<=', '<>', 'in',
     *                           'like', 'between', 'not between', 'is null', 'is not null'
     * @param mixed $value, - will be escaped
-    * @param string $combine, - combine additional where clauses with, 
-    *                       either 'AND','OR', 'NOT', 'AND NOT' 
+    * @param string $combine, - combine additional where clauses with,
+    *                       either 'AND','OR', 'NOT', 'AND NOT'
     *                           or  carry over of @value in the case the @operator is 'between' or 'not between'
     * @param string $extra - carry over of @combine in the case the operator is 'between' or 'not between'
     * @return bool/string - HAVING SQL statement, or false on error
@@ -90,199 +90,207 @@ interface ezQueryInterface
     /**
     * Return all rows from multiple tables where the join condition is met.
     *
-    * - Will perform an equal on tables by left column key, 
-    *       left column key and left table, left column key and right table, 
+    * - Will perform an equal on tables by left column key,
+    *       left column key and left table, left column key and right table,
     *           if `rightColumn` is null.
     *
-    * - Will perform an equal on tables by, 
-    *       left column key and left table, right column key and right table, 
+    * - Will perform an equal on tables by,
+    *       left column key and left table, right column key and right table,
     *           if `rightColumn` not null, and `$condition` not changed.
     *
     * - Will perform the `condition` on passed in arguments, for left column, and right column.
     *           if `$condition`,  is in the array
     *
-    * @param string $leftTable - 
-    * @param string $rightTable - 
-    * @param string $leftColumn - 
-    * @param string $rightColumn - 
-    * @param string $condition -  
+    * @param string $leftTable -
+    * @param string $rightTable -
+    * @param string $leftColumn -
+    * @param string $rightColumn -
+    * @param string $tableAs -
+    * @param string $condition -
     *
     * @return bool|string JOIN sql statement, false for error
     */
     public function innerJoin(
-        string $leftTable = null, 
-        string $rightTable = null, 
-        string $leftColumn = null, string $rightColumn = null, $condition = \EQ);
+        string $leftTable = null,
+        string $rightTable = null,
+        string $leftColumn = null, string $rightColumn = null,
+        string $tableAs = null, $condition = \EQ);
 
     /**
-    * This type of join returns all rows from the LEFT-hand table 
-    * specified in the ON condition and only those rows from the other table 
+    * This type of join returns all rows from the LEFT-hand table
+    * specified in the ON condition and only those rows from the other table
     * where the joined fields are equal (join condition is met).
     *
-    * - Will perform an equal on tables by left column key, 
-    *       left column key and left table, left column key and right table, 
+    * - Will perform an equal on tables by left column key,
+    *       left column key and left table, left column key and right table,
     *           if `rightColumn` is null.
     *
-    * - Will perform an equal on tables by, 
-    *       left column key and left table, right column key and right table, 
+    * - Will perform an equal on tables by,
+    *       left column key and left table, right column key and right table,
     *           if `rightColumn` not null, and `$condition` not changed.
     *
     * - Will perform the `condition` on passed in arguments, for left column, and right column.
     *           if `$condition`,  is in the array
     *
-    * @param string $leftTable - 
-    * @param string $rightTable - 
-    * @param string $leftColumn - 
-    * @param string $rightColumn - 
-    * @param string $condition -  
+    * @param string $leftTable -
+    * @param string $rightTable -
+    * @param string $leftColumn -
+    * @param string $rightColumn -
+    * @param string $tableAs -
+    * @param string $condition -
     *
     * @return bool|string JOIN sql statement, false for error
     */
     public function leftJoin(
-        string $leftTable = null, 
-        string $rightTable = null, 
-        string $leftColumn = null, string $rightColumn = null, $condition = \EQ);
+        string $leftTable = null,
+        string $rightTable = null,
+        string $leftColumn = null, string $rightColumn = null,
+        string $tableAs = null, $condition = \EQ);
 
     /**
-    * This type of join returns all rows from the RIGHT-hand table 
-    * specified in the ON condition and only those rows from the other table 
+    * This type of join returns all rows from the RIGHT-hand table
+    * specified in the ON condition and only those rows from the other table
     * where the joined fields are equal (join condition is met).
     *
-    * - Will perform an equal on tables by left column key, 
-    *       left column key and left table, left column key and right table, 
+    * - Will perform an equal on tables by left column key,
+    *       left column key and left table, left column key and right table,
     *           if `rightColumn` is null.
     *
-    * - Will perform an equal on tables by, 
-    *       left column key and left table, right column key and right table, 
+    * - Will perform an equal on tables by,
+    *       left column key and left table, right column key and right table,
     *           if `rightColumn` not null, and `$condition` not changed.
     *
     * - Will perform the `condition` on passed in arguments, for left column, and right column.
     *           if `$condition`,  is in the array
     *
-    * @param string $leftTable - 
-    * @param string $rightTable - 
-    * @param string $leftColumn - 
-    * @param string $rightColumn - 
-    * @param string $condition -  
+    * @param string $leftTable -
+    * @param string $rightTable -
+    * @param string $leftColumn -
+    * @param string $rightColumn -
+    * @param string $tableAs -
+    * @param string $condition -
     *
     * @return bool|string JOIN sql statement, false for error
     */
     public function rightJoin(
-        string $leftTable = null, 
-        string $rightTable = null, 
-        string $leftColumn = null, string $rightColumn = null, $condition = \EQ);
+        string $leftTable = null,
+        string $rightTable = null,
+        string $leftColumn = null, string $rightColumn = null,
+        string $tableAs = null, $condition = \EQ);
 
     /**
-    * This type of join returns all rows from the LEFT-hand table and RIGHT-hand table 
+    * This type of join returns all rows from the LEFT-hand table and RIGHT-hand table
     * with NULL values in place where the join condition is not met.
     *
-    * - Will perform an equal on tables by left column key, 
-    *       left column key and left table, left column key and right table, 
+    * - Will perform an equal on tables by left column key,
+    *       left column key and left table, left column key and right table,
     *           if `rightColumn` is null.
     *
-    * - Will perform an equal on tables by, 
-    *       left column key and left table, right column key and right table, 
+    * - Will perform an equal on tables by,
+    *       left column key and left table, right column key and right table,
     *           if `rightColumn` not null, and `$condition` not changed.
     *
     * - Will perform the `condition` on passed in arguments, for left column, and right column.
     *           if `$condition`,  is in the array
     *
-    * @param string $leftTable - 
-    * @param string $rightTable - 
-    * @param string $leftColumn - 
-    * @param string $rightColumn - 
-    * @param string $condition -  
+    * @param string $leftTable -
+    * @param string $rightTable -
+    * @param string $leftColumn -
+    * @param string $rightColumn -
+    * @param string $tableAs -
+    * @param string $condition -
     *
     * @return bool|string JOIN sql statement, false for error
     */
     public function fullJoin(
-        string $leftTable = null, 
-        string $rightTable = null, 
-        string $leftColumn = null, string $rightColumn = null, $condition = \EQ);
+        string $leftTable = null,
+        string $rightTable = null,
+        string $leftColumn = null, string $rightColumn = null,
+        string $tableAs = null, $condition = \EQ);
 
 	/**
-    * Returns an `UNION` SELECT SQL string, given the 
+    * Returns an `UNION` SELECT SQL string, given the
     *   - table, column fields, conditions or conditional array.
     *
     * In the following format:
     * ```
     * union(
     *   table,
-    *   columns, 
+    *   columns,
     *   // innerJoin(), leftJoin(), rightJoin(), fullJoin() alias of
-    *   joining(inner|left|right|full, leftTable, rightTable, leftColumn, rightColumn, equal condition), 
-    *   where( eq( columns, values, _AND ), like( columns, _d ) ), 
-    *   groupBy( columns ), 
-    *   having( between( columns, values1, values2 ) ), 
+    *   joining(inner|left|right|full, leftTable, rightTable, leftColumn, rightColumn, equal condition),
+    *   where( eq( columns, values, _AND ), like( columns, _d ) ),
+    *   groupBy( columns ),
+    *   having( between( columns, values1, values2 ) ),
     *   orderBy( columns, desc ),
     *   limit( numberOfRecords, offset )
     *);
-    * ``` 
+    * ```
     * @param $table, - database table to access
     * @param $columnFields, - table columns, string or array
     * @param mixed $conditions - same as selecting method.
-    *   
+    *
     * @return bool|string - false for error
 	*/
     public function union(string $table = null, $columnFields = '*', ...$conditions);
 
 	/**
-    * Returns an `UNION ALL` SELECT SQL string, given the 
+    * Returns an `UNION ALL` SELECT SQL string, given the
     *   - table, column fields, conditions or conditional array.
     *
     * In the following format:
     * ```
     * unionAll(
     *   table,
-    *   columns, 
+    *   columns,
     *   // innerJoin(), leftJoin(), rightJoin(), fullJoin() alias of
-    *   joining(inner|left|right|full, leftTable, rightTable, leftColumn, rightColumn, equal condition), 
-    *   where( eq( columns, values, _AND ), like( columns, _d ) ), 
-    *   groupBy( columns ), 
-    *   having( between( columns, values1, values2 ) ), 
+    *   joining(inner|left|right|full, leftTable, rightTable, leftColumn, rightColumn, equal condition),
+    *   where( eq( columns, values, _AND ), like( columns, _d ) ),
+    *   groupBy( columns ),
+    *   having( between( columns, values1, values2 ) ),
     *   orderBy( columns, desc ),
     *   limit( numberOfRecords, offset )
     *);
-    * ``` 
+    * ```
     * @param $table, - database table to access
     * @param $columnFields, - table columns, string or array
     * @param mixed $conditions - same as selecting method.
-    *   
+    *
     * @return bool|string - false for error
 	*/
     public function unionAll(string $table = null, $columnFields = '*', ...$conditions);
 
     /**
-    * Specifies an ordering for the query results.  
-    * @param string $orderBy - The column. 
-    * @param string $order - The ordering direction. 
+    * Specifies an ordering for the query results.
+    * @param string $orderBy - The column.
+    * @param string $order - The ordering direction.
     *
     * @return string - ORDER BY SQL statement, or false on error
     */
     public function orderBy($orderBy, $order);
 
     /**
-    * Specifies records from one or more tables in a database and 
+    * Specifies records from one or more tables in a database and
     * limit the number of records returned.
     *
     * @param int $numberOf - set limit number of records to be returned.
-    * @param int $offset - Optional. The first row returned by LIMIT will be determined by offset value. 
+    * @param int $offset - Optional. The first row returned by LIMIT will be determined by offset value.
     *
     * @return string - LIMIT and/or OFFSET SQL statement, or false on error
     */
     public function limit($numberOf, $offset = null);
 
  	/**
-     * Helper returns an WHERE sql clause string. 
+     * Helper returns an WHERE sql clause string.
      *
      * format:
-     *   `where( comparison(x, y, and) )` 
+     *   `where( comparison(x, y, and) )`
      *
-     * example: 
+     * example:
      *   `where( eq(key, value ), like('key', '_%?');`
      *
      * @param array $whereConditions - In the following format:
-     * 
+     *
      *   eq('key/Field/Column', $value, _AND), // combine next expression
      *   neq('key/Field/Column', $value, _OR), // will combine next expression again
      *   ne('key/Field/Column', $value), // the default is _AND so will combine next expression
@@ -300,29 +308,29 @@ interface ezQueryInterface
      *   notBetween('key/Field/Column', $value, $value2)
      *
 	 * @return mixed bool/string - WHERE SQL statement, or false on error
-	 */        
+	 */
     public function where( ...$whereConditions);
-    
+
 	/**
-    * Returns an SQL string or result set, given the 
+    * Returns an SQL string or result set, given the
     *   - table, column fields, conditions or conditional array.
     *
     * In the following format:
     * ```
     * selecting(
     *   table,
-    *   columns, 
+    *   columns,
     *   // innerJoin(), leftJoin(), rightJoin(), fullJoin() alias of
-    *   joining(inner|left|right|full, leftTable, rightTable, leftColumn, rightColumn, equal condition), 
-    *   where( eq( columns, values, _AND ), like( columns, _d ) ), 
-    *   groupBy( columns ), 
-    *   having( between( columns, values1, values2 ) ), 
+    *   joining(inner|left|right|full, leftTable, rightTable, leftColumn, rightColumn, equal condition),
+    *   where( eq( columns, values, _AND ), like( columns, _d ) ),
+    *   groupBy( columns ),
+    *   having( between( columns, values1, values2 ) ),
     *   orderBy( columns, desc ),
     *   limit( numberOfRecords, offset ),
     *   union(table, columnFields, conditions), // Returns an select SQL string with `UNION`
     *   unionAll(table, columnFields, conditions) // Returns an select SQL string with `UNION ALL`
     *);
-    * ``` 
+    * ```
     * @param $table, - database table to access
     * @param $columnFields, - table columns, string or array
     * @param mixed $conditions - of the following parameters:
@@ -334,34 +342,34 @@ interface ezQueryInterface
     *   @param $orderby, - ordering by clause for the query
     *   @param $limit, - limit clause the number of records
     *   @param $union/$unionAll - union clause combine the result sets and removes duplicate rows/does not remove
-    *   
+    *
     * @return mixed result set - see docs for more details, or false for error
 	*/
     public function selecting(string $table = null, $columnFields = '*', ...$conditions);
 
-	/** 
+	/**
     * Does an create select statement by calling selecting method
     *
-    * @param $newTable, - new database table to be created 
+    * @param $newTable, - new database table to be created
     * @param $fromColumns - the columns from old database table
-    * @param $oldTable - old database table 
+    * @param $oldTable - old database table
     * @param $fromWhere, - where clause ( array(x, =, y, and, extra) ) or ( "x  =  y  and  extra" )
     *
     * @return mixed bool/result - false for error
 	*/
     public function create_select(string $newTable, $fromColumns, $oldTable = null, ...$conditions);
-    
+
     /**
     * Does an select into statement by calling selecting method
-    * @param $newTable, - new database table to be created 
+    * @param $newTable, - new database table to be created
     * @param $fromColumns - the columns from old database table
-    * @param $oldTable - old database table 
+    * @param $oldTable - old database table
     * @param $fromWhere, - where clause ( array(x, =, y, and, extra) ) or ( "x  =  y  and  extra" )
     *
     * @return mixed bool/result - false for error
 	*/
     public function select_into(string $newTable, $fromColumns, $oldTable = null, ...$conditions);
-		
+
 	/**
 	* Does an update query with an array, by conditional operator array
 	* @param $table, - database table to access
@@ -371,8 +379,8 @@ interface ezQueryInterface
 	* @return mixed bool/results - false for error
 	*/
     public function update(string $table = null, $keyAndValue, ...$whereConditions);
-         
-	/** 
+
+	/**
     * Helper does the actual delete query with an array
 	* @return mixed bool/results - false for error
 	*/
@@ -393,10 +401,10 @@ interface ezQueryInterface
     * @return mixed bool/id of inserted record, or false for error
 	*/
     public function insert(string $table = null, $keyAndValue);
-    
+
 	/**
     * Does an insert into select statement by calling insert method helper then selecting method
-    * @param $toTable, - database table to insert table into 
+    * @param $toTable, - database table to insert table into
     * @param $toColumns - the receiving columns from other table columns, leave blank for all or array of column fields
     * @param $WhereKey, - where clause ( array(x, =, y, and, extra) ) or ( "x = y and extra" )
     *
@@ -407,21 +415,21 @@ interface ezQueryInterface
 
    /**
     * Creates an database table and columns, by either:
-    *  - array( column, datatype, ...value/options arguments ) // calls create_schema() 
+    *  - array( column, datatype, ...value/options arguments ) // calls create_schema()
     *  - column( column, datatype, ...value/options arguments ) // returns string
     *  - primary( primary_key_label, ...primaryKeys) // returns string
     *  - foreign( foreign_key_label, ...foreignKeys) // returns string
     *  - unique( unique_key_label, ...uniqueKeys) // returns string
-    * 
+    *
     * @param string $table, - The name of the db table that you wish to create
     * @param mixed $schemas, - An array of:
     *
     * @param string $column|CONSTRAINT, - column name/CONSTRAINT usage for PRIMARY|FOREIGN KEY
     * @param string $type|$constraintName, - data type for column/primary|foreign constraint name
-    * @param mixed $size|...$primaryForeignKeys, 
+    * @param mixed $size|...$primaryForeignKeys,
     * @param mixed $value, - column should be NULL or NOT NULL. If omitted, assumes NULL
     * @param mixed $default - Optional. It is the value to assign to the column
-    * 
+    *
     * @return mixed results of query() call
     */
    public function create(string $table = null, ...$schemas);


### PR DESCRIPTION
Fixes ezSQL#174
Removed check for `$columnFields` being empty, and added dots between table and column names in query builder