### PR TITLE
Clear func calls during flush

### DIFF
--- a/lib/ezsqlModel.php
+++ b/lib/ezsqlModel.php
@@ -258,7 +258,8 @@ class ezsqlModel extends ezQuery implements ezsqlModelInterface
 		// Get rid of these
 		$this->last_result = null;
 		$this->col_info = array();
-		$this->last_query = null;
+                $this->last_query = null;
+                $this->all_func_calls = array();
 		$this->from_disk_cache = false;
 		$this->clearPrepare();
 	}


### PR DESCRIPTION
I ran into a bit of a memory "leak" when running, what do you recommend? It looks like the function call stack was getting filled up:

```
PHP Fatal error:  Allowed memory size of 4294967296 bytes exhausted (tried to allocate 536870920 bytes) in /htdocs/lib/vendor/ezsql/ezsql/lib/ezsqlModel.php on line 272
```

A solution is to clear it out during `flush()`..