### PR TITLE
Where group

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,15 @@ notBetween('column', $value, $value2)
 ```
 
 ```php
+// To allow simple grouping of basic $whereConditions,
+// wrap the following around a group of the above comparison
+// expressions within the where( ...$whereConditions) clause
+grouping( eq(key, value, combiner ), eq(key, value, combiner ) )
+// The above will wrap beginning and end grouping in a where statement
+// where required to break down your where clause.
+```
+
+```php
 // Supply the the whole query string, and placing '?' within
 // With the same number of arguments in an array.
 // It will determine arguments type, execute, and return results.

--- a/lib/ezFunctions.php
+++ b/lib/ezFunctions.php
@@ -113,12 +113,11 @@ if (!function_exists('ezFunctions')) {
      *
      * @param strings $y, - The right expression.
      * @param strings $and, - combine additional expressions with,  'AND','OR', 'NOT', 'AND NOT'.
-     * @param strings $group, - notes beginning or end of where group,  '(',')'.
      * @param strings $args - for any extras
      *
-     * function comparison($x, $operator, $y, $and=null, $group=null, ...$args)
+     * function comparison($x, $operator, $y, $and=null, ...$args)
      *  {
-     *          return array($x, $operator, $y, $and, $group, ...$args);
+     *          return array($x, $operator, $y, $and, ...$args);
      * }
      *
      * @return array
@@ -127,110 +126,110 @@ if (!function_exists('ezFunctions')) {
     /**
      * Creates an equality comparison expression with the given arguments.
      */
-    function eq($x, $y, $and = null, $group = null, ...$args)
+    function eq($x, $y, $and = null, ...$args)
     {
         $expression = array();
-        \array_push($expression, $x, \EQ, $y, $and, $group, ...$args);
+        \array_push($expression, $x, \EQ, $y, $and, ...$args);
         return $expression;
     }
 
     /**
      * Creates a non equality comparison expression with the given arguments.
      */
-    function neq($x, $y, $and = null, $group = null, ...$args)
+    function neq($x, $y, $and = null, ...$args)
     {
         $expression = array();
-        \array_push($expression, $x, \NEQ, $y, $and, $group, ...$args);
+        \array_push($expression, $x, \NEQ, $y, $and, ...$args);
         return $expression;
     }
 
     /**
      * Creates the other non equality comparison expression with the given arguments.
      */
-    function ne($x, $y, $and = null, $group = null, ...$args)
+    function ne($x, $y, $and = null, ...$args)
     {
         $expression = array();
-        \array_push($expression, $x, \NE, $y, $and, $group, ...$args);
+        \array_push($expression, $x, \NE, $y, $and, ...$args);
         return $expression;
     }
 
     /**
      * Creates a lower-than comparison expression with the given arguments.
      */
-    function lt($x, $y, $and = null, $group = null, ...$args)
+    function lt($x, $y, $and = null, ...$args)
     {
         $expression = array();
-        \array_push($expression, $x, \LT, $y, $and, $group, ...$args);
+        \array_push($expression, $x, \LT, $y, $and, ...$args);
         return $expression;
     }
 
     /**
      * Creates a lower-than-equal comparison expression with the given arguments.
      */
-    function lte($x, $y, $and = null, $group = null, ...$args)
+    function lte($x, $y, $and = null, ...$args)
     {
         $expression = array();
-        \array_push($expression, $x, \LTE, $y, $and, $group, ...$args);
+        \array_push($expression, $x, \LTE, $y, $and, ...$args);
         return $expression;
     }
 
     /**
      * Creates a greater-than comparison expression with the given arguments.
      */
-    function gt($x, $y, $and = null, $group = null, ...$args)
+    function gt($x, $y, $and = null, ...$args)
     {
         $expression = array();
-        \array_push($expression, $x, \GT, $y, $and, $group, ...$args);
+        \array_push($expression, $x, \GT, $y, $and, ...$args);
         return $expression;
     }
 
     /**
      * Creates a greater-than-equal comparison expression with the given arguments.
      */
-    function gte($x, $y, $and = null, $group = null, ...$args)
+    function gte($x, $y, $and = null, ...$args)
     {
         $expression = array();
-        \array_push($expression, $x, \GTE, $y, $and, $group, ...$args);
+        \array_push($expression, $x, \GTE, $y, $and, ...$args);
         return $expression;
     }
 
     /**
      * Creates an IS NULL expression with the given arguments.
      */
-    function isNull($x, $y = 'null', $and = null, $group = null, ...$args)
+    function isNull($x, $y = 'null', $and = null, ...$args)
     {
         $expression = array();
-        \array_push($expression, $x, \_isNULL, $y, $and, $group, ...$args);
+        \array_push($expression, $x, \_isNULL, $y, $and, ...$args);
         return $expression;
     }
 
     /**
      * Creates an IS NOT NULL expression with the given arguments.
      */
-    function isNotNull($x, $y = 'null', $and = null, $group = null, ...$args)
+    function isNotNull($x, $y = 'null', $and = null, ...$args)
     {
         $expression = array();
-        \array_push($expression, $x, \_notNULL, $y, $and, $group, ...$args);
+        \array_push($expression, $x, \_notNULL, $y, $and, ...$args);
         return $expression;
     }
 
     /**
      * Creates a LIKE() comparison expression with the given arguments.
      */
-    function like($x, $y, $and = null, $group = null, ...$args)
+    function like($x, $y, $and = null, ...$args)
     {
         $expression = array();
-        \array_push($expression, $x, \_LIKE, $y, $and, $group, ...$args);
+        \array_push($expression, $x, \_LIKE, $y, $and, ...$args);
         return $expression;
     }
 
     /**
      * Creates a NOT LIKE() comparison expression with the given arguments.
      */
-    function notLike($x, $y, $and = null, $group = null, ...$args)
+    function notLike($x, $y, $and = null, ...$args)
     {
         $expression = array();
-        \array_push($expression, $x, \_notLIKE, $y, $and, $group, ...$args);
+        \array_push($expression, $x, \_notLIKE, $y, $and, ...$args);
         return $expression;
     }
 
@@ -260,7 +259,7 @@ if (!function_exists('ezFunctions')) {
     function between($x, $y, $y2, ...$args)
     {
         $expression = array();
-        \array_push($expression, $x, \_BETWEEN, $y, $y2, null, \_AND, ...$args);
+        \array_push($expression, $x, \_BETWEEN, $y, $y2, \_AND, ...$args);
         return $expression;
     }
 
@@ -270,7 +269,7 @@ if (!function_exists('ezFunctions')) {
     function notBetween($x, $y, $y2, ...$args)
     {
         $expression = array();
-        \array_push($expression, $x, \_notBETWEEN, $y, $y2, null, \_AND, ...$args);
+        \array_push($expression, $x, \_notBETWEEN, $y, $y2, \_AND, ...$args);
         return $expression;
     }
 

--- a/lib/ezFunctions.php
+++ b/lib/ezFunctions.php
@@ -260,7 +260,7 @@ if (!function_exists('ezFunctions')) {
     function between($x, $y, $y2, ...$args)
     {
         $expression = array();
-        \array_push($expression, $x, \_BETWEEN, $y, $y2, \_AND, ...$args);
+        \array_push($expression, $x, \_BETWEEN, $y, $y2, null, \_AND, ...$args);
         return $expression;
     }
 
@@ -270,7 +270,7 @@ if (!function_exists('ezFunctions')) {
     function notBetween($x, $y, $y2, ...$args)
     {
         $expression = array();
-        \array_push($expression, $x, \_notBETWEEN, $y, $y2, \_AND, ...$args);
+        \array_push($expression, $x, \_notBETWEEN, $y, $y2, null, \_AND, ...$args);
         return $expression;
     }
 

--- a/lib/ezFunctions.php
+++ b/lib/ezFunctions.php
@@ -113,11 +113,12 @@ if (!function_exists('ezFunctions')) {
      *
      * @param strings $y, - The right expression.
      * @param strings $and, - combine additional expressions with,  'AND','OR', 'NOT', 'AND NOT'.
+     * @param strings $group, - notes beginning or end of where group,  '(',')'.
      * @param strings $args - for any extras
      *
-     * function comparison($x, $operator, $y, $and=null, ...$args)
+     * function comparison($x, $operator, $y, $and=null, $group=null, ...$args)
      *  {
-     *          return array($x, $operator, $y, $and, ...$args);
+     *          return array($x, $operator, $y, $and, $group, ...$args);
      * }
      *
      * @return array
@@ -126,110 +127,110 @@ if (!function_exists('ezFunctions')) {
     /**
      * Creates an equality comparison expression with the given arguments.
      */
-    function eq($x, $y, $and = null, ...$args)
+    function eq($x, $y, $and = null, $group = null, ...$args)
     {
         $expression = array();
-        \array_push($expression, $x, \EQ, $y, $and, ...$args);
+        \array_push($expression, $x, \EQ, $y, $and, $group, ...$args);
         return $expression;
     }
 
     /**
      * Creates a non equality comparison expression with the given arguments.
      */
-    function neq($x, $y, $and = null, ...$args)
+    function neq($x, $y, $and = null, $group = null, ...$args)
     {
         $expression = array();
-        \array_push($expression, $x, \NEQ, $y, $and, ...$args);
+        \array_push($expression, $x, \NEQ, $y, $and, $group, ...$args);
         return $expression;
     }
 
     /**
      * Creates the other non equality comparison expression with the given arguments.
      */
-    function ne($x, $y, $and = null, ...$args)
+    function ne($x, $y, $and = null, $group = null, ...$args)
     {
         $expression = array();
-        \array_push($expression, $x, \NE, $y, $and, ...$args);
+        \array_push($expression, $x, \NE, $y, $and, $group, ...$args);
         return $expression;
     }
 
     /**
      * Creates a lower-than comparison expression with the given arguments.
      */
-    function lt($x, $y, $and = null, ...$args)
+    function lt($x, $y, $and = null, $group = null, ...$args)
     {
         $expression = array();
-        \array_push($expression, $x, \LT, $y, $and, ...$args);
+        \array_push($expression, $x, \LT, $y, $and, $group, ...$args);
         return $expression;
     }
 
     /**
      * Creates a lower-than-equal comparison expression with the given arguments.
      */
-    function lte($x, $y, $and = null, ...$args)
+    function lte($x, $y, $and = null, $group = null, ...$args)
     {
         $expression = array();
-        \array_push($expression, $x, \LTE, $y, $and, ...$args);
+        \array_push($expression, $x, \LTE, $y, $and, $group, ...$args);
         return $expression;
     }
 
     /**
      * Creates a greater-than comparison expression with the given arguments.
      */
-    function gt($x, $y, $and = null, ...$args)
+    function gt($x, $y, $and = null, $group = null, ...$args)
     {
         $expression = array();
-        \array_push($expression, $x, \GT, $y, $and, ...$args);
+        \array_push($expression, $x, \GT, $y, $and, $group, ...$args);
         return $expression;
     }
 
     /**
      * Creates a greater-than-equal comparison expression with the given arguments.
      */
-    function gte($x, $y, $and = null, ...$args)
+    function gte($x, $y, $and = null, $group = null, ...$args)
     {
         $expression = array();
-        \array_push($expression, $x, \GTE, $y, $and, ...$args);
+        \array_push($expression, $x, \GTE, $y, $and, $group, ...$args);
         return $expression;
     }
 
     /**
      * Creates an IS NULL expression with the given arguments.
      */
-    function isNull($x, $y = 'null', $and = null, ...$args)
+    function isNull($x, $y = 'null', $and = null, $group = null, ...$args)
     {
         $expression = array();
-        \array_push($expression, $x, \_isNULL, $y, $and, ...$args);
+        \array_push($expression, $x, \_isNULL, $y, $and, $group, ...$args);
         return $expression;
     }
 
     /**
      * Creates an IS NOT NULL expression with the given arguments.
      */
-    function isNotNull($x, $y = 'null', $and = null, ...$args)
+    function isNotNull($x, $y = 'null', $and = null, $group = null, ...$args)
     {
         $expression = array();
-        \array_push($expression, $x, \_notNULL, $y, $and, ...$args);
+        \array_push($expression, $x, \_notNULL, $y, $and, $group, ...$args);
         return $expression;
     }
 
     /**
      * Creates a LIKE() comparison expression with the given arguments.
      */
-    function like($x, $y, $and = null, ...$args)
+    function like($x, $y, $and = null, $group = null, ...$args)
     {
         $expression = array();
-        \array_push($expression, $x, \_LIKE, $y, $and, ...$args);
+        \array_push($expression, $x, \_LIKE, $y, $and, $group, ...$args);
         return $expression;
     }
 
     /**
      * Creates a NOT LIKE() comparison expression with the given arguments.
      */
-    function notLike($x, $y, $and = null, ...$args)
+    function notLike($x, $y, $and = null, $group = null, ...$args)
     {
         $expression = array();
-        \array_push($expression, $x, \_notLIKE, $y, $and, ...$args);
+        \array_push($expression, $x, \_notLIKE, $y, $and, $group, ...$args);
         return $expression;
     }
 
@@ -349,6 +350,14 @@ if (!function_exists('ezFunctions')) {
             : false;
     }
 
+    function whereGroup(...$args)
+    {
+        $ezQuery = \getInstance();
+        return ($ezQuery instanceof DatabaseInterface)
+            ? $ezQuery->whereGroup(...$args)
+            : false;
+    }
+
     function groupBy($groupBy)
     {
         $ezQuery = \getInstance();
@@ -374,7 +383,7 @@ if (!function_exists('ezFunctions')) {
         $condition = \EQ
     ) {
         $ezQuery = \getInstance();
-        return ($ezQuery instanceOf DatabaseInterface)
+        return ($ezQuery instanceof DatabaseInterface)
             ? $ezQuery->innerJoin($leftTable, $rightTable, $leftColumn, $rightColumn, $tableAs, $condition)
             : false;
     }
@@ -388,7 +397,7 @@ if (!function_exists('ezFunctions')) {
         $condition = \EQ
     ) {
         $ezQuery = \getInstance();
-        return ($ezQuery instanceOf DatabaseInterface)
+        return ($ezQuery instanceof DatabaseInterface)
             ? $ezQuery->leftJoin($leftTable, $rightTable, $leftColumn, $rightColumn, $tableAs, $condition)
             : false;
     }
@@ -402,7 +411,7 @@ if (!function_exists('ezFunctions')) {
         $condition = \EQ
     ) {
         $ezQuery = \getInstance();
-        return ($ezQuery instanceOf DatabaseInterface)
+        return ($ezQuery instanceof DatabaseInterface)
             ? $ezQuery->rightJoin($leftTable, $rightTable, $leftColumn, $rightColumn, $tableAs, $condition)
             : false;
     }
@@ -416,7 +425,7 @@ if (!function_exists('ezFunctions')) {
         $condition = \EQ
     ) {
         $ezQuery = \getInstance();
-        return ($ezQuery instanceOf DatabaseInterface)
+        return ($ezQuery instanceof DatabaseInterface)
             ? $ezQuery->fullJoin($leftTable, $rightTable, $leftColumn, $rightColumn, $tableAs, $condition)
             : false;
     }

--- a/lib/ezFunctions.php
+++ b/lib/ezFunctions.php
@@ -494,6 +494,19 @@ if (!function_exists('ezFunctions')) {
             : false;
     }
 
+    function flattenWhereConditions($whereConditions)
+    {
+        $whereConditionsReturn = [];
+        foreach ($whereConditions as $whereCondition) {
+            if (!empty($whereCondition[0]) && is_array($whereCondition[0])) {
+                $whereConditionsReturn = array_merge($whereConditionsReturn, flattenWhereConditions($whereCondition));
+            } else {
+                $whereConditionsReturn[] = $whereCondition;
+            }
+        }
+        return $whereConditionsReturn;
+    }
+
     function ezFunctions()
     {
         return true;

--- a/lib/ezFunctions.php
+++ b/lib/ezFunctions.php
@@ -349,11 +349,11 @@ if (!function_exists('ezFunctions')) {
             : false;
     }
 
-    function whereGroup(...$args)
+    function grouping(...$args)
     {
         $ezQuery = \getInstance();
         return ($ezQuery instanceof DatabaseInterface)
-            ? $ezQuery->whereGroup(...$args)
+            ? $ezQuery->grouping(...$args)
             : false;
     }
 
@@ -491,19 +491,6 @@ if (!function_exists('ezFunctions')) {
         return ($ezQuery instanceof DatabaseInterface)
             ? $ezQuery->replace($table, $keyValue)
             : false;
-    }
-
-    function flattenWhereConditions($whereConditions)
-    {
-        $whereConditionsReturn = [];
-        foreach ($whereConditions as $whereCondition) {
-            if (!empty($whereCondition[0]) && is_array($whereCondition[0])) {
-                $whereConditionsReturn = array_merge($whereConditionsReturn, flattenWhereConditions($whereCondition));
-            } else {
-                $whereConditionsReturn[] = $whereCondition;
-            }
-        }
-        return $whereConditionsReturn;
     }
 
     function ezFunctions()

--- a/lib/ezQuery.php
+++ b/lib/ezQuery.php
@@ -391,9 +391,22 @@ class ezQuery implements ezQueryInterface
         $this->whereSQL .= "$key $isCondition NULL $combine ";
     }
 
+    private function flattenWhereConditions($whereConditions)
+    {
+        $whereConditionsReturn = [];
+        foreach ($whereConditions as $whereCondition) {
+            if (!empty($whereCondition[0]) && is_array($whereCondition[0])) {
+                $whereConditionsReturn = array_merge($whereConditionsReturn, $this->flattenWhereConditions($whereCondition));
+            } else {
+                $whereConditionsReturn[] = $whereCondition;
+            }
+        }
+        return $whereConditionsReturn;
+    }
+
     private function retrieveConditions($whereConditions)
     {
-        $whereConditions = flattenWhereConditions($whereConditions);
+        $whereConditions = $this->flattenWhereConditions($whereConditions);
         $whereKey = [];
         $whereValue = [];
         $operator = [];
@@ -442,7 +455,7 @@ class ezQuery implements ezQueryInterface
         }
     }
 
-    public function whereGroup(...$whereConditions)
+    public function grouping(...$whereConditions)
     {
         if (empty($whereConditions))
             return false;

--- a/lib/ezQuery.php
+++ b/lib/ezQuery.php
@@ -393,6 +393,7 @@ class ezQuery implements ezQueryInterface
 
     private function retrieveConditions($whereConditions)
     {
+        $whereConditions = flattenWhereConditions($whereConditions);
         $whereKey = [];
         $whereValue = [];
         $operator = [];

--- a/lib/ezQuery.php
+++ b/lib/ezQuery.php
@@ -412,7 +412,7 @@ class ezQuery implements ezQueryInterface
                 $combiner[] = \_AND;
                 $extra[] = null;
             } else {
-                if (isset($checkFields[0])) {
+                if (!empty($checkFields[0])) {
                     $whereKey[] = $checkFields[0];
                     $whereValue[] = (isset($checkFields[2])) ? $checkFields[2] : '';
                     $combiner[] = (isset($checkFields[3])) ? $checkFields[3] : \_AND;

--- a/lib/ezQueryInterface.php
+++ b/lib/ezQueryInterface.php
@@ -298,10 +298,10 @@ interface ezQueryInterface
      * Helper adds WHERE grouping to the conditions
      *
      * format:
-     *   `whereGroup( comparison(x, y, and) )`
+     *   `grouping( comparison(x, y, and) )`
      *
      * example:
-     *   `whereGroup( eq(key, value, combiner ), eq(key, value, combiner ) );`
+     *   `grouping( eq(key, value, combiner ), eq(key, value, combiner ) );`
      *
      * @param array $whereConditions - In the following format:
      *
@@ -319,7 +319,7 @@ interface ezQueryInterface
      *
      * @return array modified conditions
      */
-    public function whereGroup(...$whereConditions);
+    public function grouping(...$whereConditions);
 
     /**
      * Helper returns an WHERE sql clause string.

--- a/lib/ezQueryInterface.php
+++ b/lib/ezQueryInterface.php
@@ -295,6 +295,33 @@ interface ezQueryInterface
     public function limit($numberOf, $offset = null);
 
     /**
+     * Helper adds WHERE grouping to the conditions
+     *
+     * format:
+     *   `whereGroup( comparison(x, y, and) )`
+     *
+     * example:
+     *   `whereGroup( eq(key, value, combiner ), eq(key, value, combiner ) );`
+     *
+     * @param array $whereConditions - In the following format:
+     *
+     *   eq('key/Field/Column', $value, _AND), // combine next expression
+     *   neq('key/Field/Column', $value, _OR), // will combine next expression again
+     *   ne('key/Field/Column', $value), // the default is _AND so will combine next expression
+     *   lt('key/Field/Column', $value)
+     *   lte('key/Field/Column', $value)
+     *   gt('key/Field/Column', $value)
+     *   gte('key/Field/Column', $value)
+     *   isNull('key/Field/Column')
+     *   isNotNull('key/Field/Column')
+     *   like('key/Field/Column', '_%')
+     *   notLike('key/Field/Column', '_%')
+     *
+     * @return mixed bool/string - WHERE SQL statement, or false on error
+     */
+    public function whereGroup(...$whereConditions);
+
+    /**
      * Helper returns an WHERE sql clause string.
      *
      * format:
@@ -321,7 +348,7 @@ interface ezQueryInterface
      *   between('key/Field/Column', $value, $value2)
      *   notBetween('key/Field/Column', $value, $value2)
      *
-     * @return mixed bool/string - WHERE SQL statement, or false on error
+     * @return array modified conditions
      */
     public function where(...$whereConditions);
 

--- a/lib/ezQueryInterface.php
+++ b/lib/ezQueryInterface.php
@@ -317,7 +317,7 @@ interface ezQueryInterface
      *   like('key/Field/Column', '_%')
      *   notLike('key/Field/Column', '_%')
      *
-     * @return mixed bool/string - WHERE SQL statement, or false on error
+     * @return array modified conditions
      */
     public function whereGroup(...$whereConditions);
 
@@ -348,7 +348,7 @@ interface ezQueryInterface
      *   between('key/Field/Column', $value, $value2)
      *   notBetween('key/Field/Column', $value, $value2)
      *
-     * @return array modified conditions
+     * @return mixed bool/string - WHERE SQL statement, or false on error
      */
     public function where(...$whereConditions);
 

--- a/tests/pdo/pdo_mysqlTest.php
+++ b/tests/pdo/pdo_mysqlTest.php
@@ -265,6 +265,26 @@ class pdo_mysqlTest extends EZTestCase
         $this->assertEquals(0, $this->object->query('DROP TABLE unit_test'));
     }
 
+    public function testWhereGroup()
+    {
+        $this->assertTrue($this->object->connect('mysql:host=' . self::TEST_DB_HOST . ';dbname=' . self::TEST_DB_NAME . ';port=' . self::TEST_DB_PORT, self::TEST_DB_USER, self::TEST_DB_PASSWORD));
+        $this->object->query('CREATE TABLE unit_test(id integer, test_key varchar(50), active tinyint(1), PRIMARY KEY (ID))');
+        $this->object->insert('unit_test', array('id' => '1', 'test_key' => 'testing 1', 'active' => 1));
+        $this->object->insert('unit_test', array('id' => '2', 'test_key' => 'testing 2', 'active' => 0));
+        $this->object->insert('unit_test', array('id' => '3', 'test_key' => 'testing 3', 'active' => 1));
+        $this->object->insert('unit_test', array('id' => '4', 'test_key' => 'testing 4', 'active' => 1));
+
+        $result = $this->object->selecting('unit_test', '*', where(eq('active', '1'), whereGroup(like('test_key', '%1%', _OR), like('test_key', '%3%', _OR))));
+        $i = 1;
+        foreach ($result as $row) {
+            $this->assertEquals($i, $row->id);
+            $this->assertEquals('testing ' . $i, $row->test_key);
+            $i = $i + 2;
+        }
+
+        $this->assertEquals(0, $this->object->query('DROP TABLE unit_test'));
+    }
+
     public function testJoins()
     {
         $this->assertTrue($this->object->connect('mysql:host=' . self::TEST_DB_HOST . ';dbname=' . self::TEST_DB_NAME . ';port=' . self::TEST_DB_PORT, self::TEST_DB_USER, self::TEST_DB_PASSWORD));

--- a/tests/pdo/pdo_mysqlTest.php
+++ b/tests/pdo/pdo_mysqlTest.php
@@ -265,7 +265,7 @@ class pdo_mysqlTest extends EZTestCase
         $this->assertEquals(0, $this->object->query('DROP TABLE unit_test'));
     }
 
-    public function testWhereGroup()
+    public function testWhereGrouping()
     {
         $this->assertTrue($this->object->connect('mysql:host=' . self::TEST_DB_HOST . ';dbname=' . self::TEST_DB_NAME . ';port=' . self::TEST_DB_PORT, self::TEST_DB_USER, self::TEST_DB_PASSWORD));
         $this->object->query('CREATE TABLE unit_test(id integer, test_key varchar(50), active tinyint(1), PRIMARY KEY (ID))');
@@ -274,7 +274,7 @@ class pdo_mysqlTest extends EZTestCase
         $this->object->insert('unit_test', array('id' => '3', 'test_key' => 'testing 3', 'active' => 1));
         $this->object->insert('unit_test', array('id' => '4', 'test_key' => 'testing 4', 'active' => 1));
 
-        $result = $this->object->selecting('unit_test', '*', where(eq('active', '1'), whereGroup(like('test_key', '%1%', _OR), like('test_key', '%3%'))));
+        $result = $this->object->selecting('unit_test', '*', where(eq('active', '1'), grouping(like('test_key', '%1%', _OR), like('test_key', '%3%'))));
         $i = 1;
         foreach ($result as $row) {
             $this->assertEquals($i, $row->id);

--- a/tests/pdo/pdo_mysqlTest.php
+++ b/tests/pdo/pdo_mysqlTest.php
@@ -274,7 +274,7 @@ class pdo_mysqlTest extends EZTestCase
         $this->object->insert('unit_test', array('id' => '3', 'test_key' => 'testing 3', 'active' => 1));
         $this->object->insert('unit_test', array('id' => '4', 'test_key' => 'testing 4', 'active' => 1));
 
-        $result = $this->object->selecting('unit_test', '*', where(eq('active', '1'), whereGroup(like('test_key', '%1%', _OR), like('test_key', '%3%', _OR))));
+        $result = $this->object->selecting('unit_test', '*', where(eq('active', '1'), whereGroup(like('test_key', '%1%', _OR), like('test_key', '%3%'))));
         $i = 1;
         foreach ($result as $row) {
             $this->assertEquals($i, $row->id);

--- a/tests/pdo/pdo_pgsqlTest.php
+++ b/tests/pdo/pdo_pgsqlTest.php
@@ -189,6 +189,24 @@ class pdo_pgsqlTest extends EZTestCase
         }
     }
 
+    public function testWhereGroup()
+    {
+        $this->assertTrue($this->object->connect('pgsql:host=' . self::TEST_DB_HOST . ';dbname=' . self::TEST_DB_NAME . ';port=' . self::TEST_DB_PORT, self::TEST_DB_USER, self::TEST_DB_PASSWORD));
+        $this->object->query('CREATE TABLE unit_test(id integer, test_key varchar(50), active tinyint(1), PRIMARY KEY (ID))');
+        $this->object->insert('unit_test', array('id' => '1', 'test_key' => 'testing 1', 'active' => 1));
+        $this->object->insert('unit_test', array('id' => '2', 'test_key' => 'testing 2', 'active' => 0));
+        $this->object->insert('unit_test', array('id' => '3', 'test_key' => 'testing 3', 'active' => 1));
+        $this->object->insert('unit_test', array('id' => '4', 'test_key' => 'testing 4', 'active' => 1));
+
+        $result = $this->object->selecting('unit_test', '*', where(eq('active', '1'), whereGroup(like('test_key', '%1%', _OR), like('test_key', '%3%', _OR))));
+        $i = 1;
+        foreach ($result as $row) {
+            $this->assertEquals($i, $row->id);
+            $this->assertEquals('testing ' . $i, $row->test_key);
+            $i = $i + 2;
+        }
+    }
+
     public function testJoins()
     {
         $this->assertTrue($this->object->connect('pgsql:host=' . self::TEST_DB_HOST . ';dbname=' . self::TEST_DB_NAME . ';port=' . self::TEST_DB_PORT, self::TEST_DB_USER, self::TEST_DB_PASSWORD));

--- a/tests/pdo/pdo_pgsqlTest.php
+++ b/tests/pdo/pdo_pgsqlTest.php
@@ -189,7 +189,7 @@ class pdo_pgsqlTest extends EZTestCase
         }
     }
 
-    public function testWhereGroup()
+    public function testWhereGrouping()
     {
         $this->assertTrue($this->object->connect('pgsql:host=' . self::TEST_DB_HOST . ';dbname=' . self::TEST_DB_NAME . ';port=' . self::TEST_DB_PORT, self::TEST_DB_USER, self::TEST_DB_PASSWORD));
         $this->object->query('CREATE TABLE unit_test(id integer, test_key varchar(50), active tinyint(1), PRIMARY KEY (ID))');
@@ -198,7 +198,7 @@ class pdo_pgsqlTest extends EZTestCase
         $this->object->insert('unit_test', array('id' => '3', 'test_key' => 'testing 3', 'active' => 1));
         $this->object->insert('unit_test', array('id' => '4', 'test_key' => 'testing 4', 'active' => 1));
 
-        $result = $this->object->selecting('unit_test', '*', where(eq('active', '1'), whereGroup(like('test_key', '%1%', _OR), like('test_key', '%3%'))));
+        $result = $this->object->selecting('unit_test', '*', where(eq('active', '1'), grouping(like('test_key', '%1%', _OR), like('test_key', '%3%'))));
         $i = 1;
         foreach ($result as $row) {
             $this->assertEquals($i, $row->id);

--- a/tests/pdo/pdo_pgsqlTest.php
+++ b/tests/pdo/pdo_pgsqlTest.php
@@ -198,7 +198,7 @@ class pdo_pgsqlTest extends EZTestCase
         $this->object->insert('unit_test', array('id' => '3', 'test_key' => 'testing 3', 'active' => 1));
         $this->object->insert('unit_test', array('id' => '4', 'test_key' => 'testing 4', 'active' => 1));
 
-        $result = $this->object->selecting('unit_test', '*', where(eq('active', '1'), whereGroup(like('test_key', '%1%', _OR), like('test_key', '%3%', _OR))));
+        $result = $this->object->selecting('unit_test', '*', where(eq('active', '1'), whereGroup(like('test_key', '%1%', _OR), like('test_key', '%3%'))));
         $i = 1;
         foreach ($result as $row) {
             $this->assertEquals($i, $row->id);

--- a/tests/pdo/pdo_sqliteTest.php
+++ b/tests/pdo/pdo_sqliteTest.php
@@ -216,7 +216,7 @@ class pdo_sqliteTest extends EZTestCase
         $this->assertEquals(1, $this->object->query('DROP TABLE unit_test'));
     }
 
-    public function testWhereGroup()
+    public function testWhereGrouping()
     {
         $this->assertTrue($this->object->connect('sqlite:' . self::TEST_SQLITE_DB, '', '', array(), true));
         $this->object->query('CREATE TABLE unit_test(id integer, test_key varchar(50), active tinyint(1), PRIMARY KEY (ID))');
@@ -225,7 +225,7 @@ class pdo_sqliteTest extends EZTestCase
         $this->object->insert('unit_test', array('id' => '3', 'test_key' => 'testing 3', 'active' => 1));
         $this->object->insert('unit_test', array('id' => '4', 'test_key' => 'testing 4', 'active' => 1));
 
-        $result = $this->object->selecting('unit_test', '*', where(eq('active', '1'), whereGroup(like('test_key', '%1%', _OR), like('test_key', '%3%'))));
+        $result = $this->object->selecting('unit_test', '*', where(eq('active', '1'), grouping(like('test_key', '%1%', _OR), like('test_key', '%3%'))));
         $i = 1;
         foreach ($result as $row) {
             $this->assertEquals($i, $row->id);

--- a/tests/pdo/pdo_sqliteTest.php
+++ b/tests/pdo/pdo_sqliteTest.php
@@ -225,7 +225,7 @@ class pdo_sqliteTest extends EZTestCase
         $this->object->insert('unit_test', array('id' => '3', 'test_key' => 'testing 3', 'active' => 1));
         $this->object->insert('unit_test', array('id' => '4', 'test_key' => 'testing 4', 'active' => 1));
 
-        $result = $this->object->selecting('unit_test', '*', where(eq('active', '1'), whereGroup(like('test_key', '%1%', _OR), like('test_key', '%3%', _OR))));
+        $result = $this->object->selecting('unit_test', '*', where(eq('active', '1'), whereGroup(like('test_key', '%1%', _OR), like('test_key', '%3%'))));
         $i = 1;
         foreach ($result as $row) {
             $this->assertEquals($i, $row->id);

--- a/tests/pdo/pdo_sqliteTest.php
+++ b/tests/pdo/pdo_sqliteTest.php
@@ -216,6 +216,26 @@ class pdo_sqliteTest extends EZTestCase
         $this->assertEquals(1, $this->object->query('DROP TABLE unit_test'));
     }
 
+    public function testWhereGroup()
+    {
+        $this->assertTrue($this->object->connect('sqlite:' . self::TEST_SQLITE_DB, '', '', array(), true));
+        $this->object->query('CREATE TABLE unit_test(id integer, test_key varchar(50), active tinyint(1), PRIMARY KEY (ID))');
+        $this->object->insert('unit_test', array('id' => '1', 'test_key' => 'testing 1', 'active' => 1));
+        $this->object->insert('unit_test', array('id' => '2', 'test_key' => 'testing 2', 'active' => 0));
+        $this->object->insert('unit_test', array('id' => '3', 'test_key' => 'testing 3', 'active' => 1));
+        $this->object->insert('unit_test', array('id' => '4', 'test_key' => 'testing 4', 'active' => 1));
+
+        $result = $this->object->selecting('unit_test', '*', where(eq('active', '1'), whereGroup(like('test_key', '%1%', _OR), like('test_key', '%3%', _OR))));
+        $i = 1;
+        foreach ($result as $row) {
+            $this->assertEquals($i, $row->id);
+            $this->assertEquals('testing ' . $i, $row->test_key);
+            $i = $i + 2;
+        }
+
+        $this->assertEquals(0, $this->object->query('DROP TABLE unit_test'));
+    }
+
     public function testJoins()
     {
         $this->assertTrue($this->object->connect('sqlite:' . self::TEST_SQLITE_DB, '', '', array(), true));

--- a/tests/pdo/pdo_sqliteTest.php
+++ b/tests/pdo/pdo_sqliteTest.php
@@ -233,7 +233,7 @@ class pdo_sqliteTest extends EZTestCase
             $i = $i + 2;
         }
 
-        $this->assertEquals(0, $this->object->query('DROP TABLE unit_test'));
+        $this->assertEquals(1, $this->object->query('DROP TABLE unit_test'));
     }
 
     public function testJoins()

--- a/tests/pdo/pdo_sqlsrvTest.php
+++ b/tests/pdo/pdo_sqlsrvTest.php
@@ -202,7 +202,7 @@ class pdo_sqlsrvTest extends EZTestCase
         $this->object->insert('unit_test', array('id' => '3', 'test_key' => 'testing 3', 'active' => 1));
         $this->object->insert('unit_test', array('id' => '4', 'test_key' => 'testing 4', 'active' => 1));
 
-        $result = $this->object->selecting('unit_test', '*', where(eq('active', '1'), whereGroup(like('test_key', '%1%', _OR), like('test_key', '%3%', _OR))));
+        $result = $this->object->selecting('unit_test', '*', where(eq('active', '1'), whereGroup(like('test_key', '%1%', _OR), like('test_key', '%3%'))));
         $i = 1;
         foreach ($result as $row) {
             $this->assertEquals($i, $row->id);

--- a/tests/pdo/pdo_sqlsrvTest.php
+++ b/tests/pdo/pdo_sqlsrvTest.php
@@ -193,7 +193,7 @@ class pdo_sqlsrvTest extends EZTestCase
         }
     }
 
-    public function testWhereGroup()
+    public function testWhereGrouping()
     {
         $this->assertTrue($this->object->connect('sqlsrv:Server=' . self::TEST_DB_HOST . ';Database=' . self::TEST_DB_NAME, self::TEST_DB_USER, self::TEST_DB_PASSWORD));
         $this->object->query('CREATE TABLE unit_test(id integer, test_key varchar(50), active tinyint(1), PRIMARY KEY (ID))');
@@ -202,7 +202,7 @@ class pdo_sqlsrvTest extends EZTestCase
         $this->object->insert('unit_test', array('id' => '3', 'test_key' => 'testing 3', 'active' => 1));
         $this->object->insert('unit_test', array('id' => '4', 'test_key' => 'testing 4', 'active' => 1));
 
-        $result = $this->object->selecting('unit_test', '*', where(eq('active', '1'), whereGroup(like('test_key', '%1%', _OR), like('test_key', '%3%'))));
+        $result = $this->object->selecting('unit_test', '*', where(eq('active', '1'), grouping(like('test_key', '%1%', _OR), like('test_key', '%3%'))));
         $i = 1;
         foreach ($result as $row) {
             $this->assertEquals($i, $row->id);

--- a/tests/pdo/pdo_sqlsrvTest.php
+++ b/tests/pdo/pdo_sqlsrvTest.php
@@ -193,6 +193,24 @@ class pdo_sqlsrvTest extends EZTestCase
         }
     }
 
+    public function testWhereGroup()
+    {
+        $this->assertTrue($this->object->connect('sqlsrv:Server=' . self::TEST_DB_HOST . ';Database=' . self::TEST_DB_NAME, self::TEST_DB_USER, self::TEST_DB_PASSWORD));
+        $this->object->query('CREATE TABLE unit_test(id integer, test_key varchar(50), active tinyint(1), PRIMARY KEY (ID))');
+        $this->object->insert('unit_test', array('id' => '1', 'test_key' => 'testing 1', 'active' => 1));
+        $this->object->insert('unit_test', array('id' => '2', 'test_key' => 'testing 2', 'active' => 0));
+        $this->object->insert('unit_test', array('id' => '3', 'test_key' => 'testing 3', 'active' => 1));
+        $this->object->insert('unit_test', array('id' => '4', 'test_key' => 'testing 4', 'active' => 1));
+
+        $result = $this->object->selecting('unit_test', '*', where(eq('active', '1'), whereGroup(like('test_key', '%1%', _OR), like('test_key', '%3%', _OR))));
+        $i = 1;
+        foreach ($result as $row) {
+            $this->assertEquals($i, $row->id);
+            $this->assertEquals('testing ' . $i, $row->test_key);
+            $i = $i + 2;
+        }
+    }
+
     public function testJoins()
     {
         $this->assertTrue($this->object->connect('sqlsrv:Server=' . self::TEST_DB_HOST . ';Database=' . self::TEST_DB_NAME, self::TEST_DB_USER, self::TEST_DB_PASSWORD));


### PR DESCRIPTION
Resolves #164 

**UPDATE:** There are no longer breaking changes

**Example code from `pdo\pdo_mysqlTest.php` file:**

```php
$db->selecting(
    'unit_test', 
    '*', 
    where(
        eq('active', '1'),
        whereGroup(
           like('test_key', '%1%', _OR),
           like('test_key', '%3%')
        )
    )
);
```

**or another example without the function**

```php
$db->selecting(
    'unit_test', 
    '*', 
    where(
        eq('active', '1'),
        like('test_key', '%1%', _OR, '('),
        like('test_key', '%3%', null, ')')
    )
);
```

The combiner will add itself at the end of the group.