### PR TITLE
Fix query prepared empty array

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+/.vscode
+/.idea
 /nbproject/private/
 /nbproject/
 *.lock

--- a/lib/Database/ez_mysqli.php
+++ b/lib/Database/ez_mysqli.php
@@ -283,7 +283,7 @@ class ez_mysqli extends ezsqlModel implements DatabaseInterface
         }
 
         $params = [];
-        if ( !empty( $param ) && \is_array( $param )) {
+        if ( !empty( $param ) && \is_array( $param ) ) {
             $types = \array_reduce(
                 $param ,
                 function( $string , &$arg ) use ( &$params ) {
@@ -303,6 +303,7 @@ class ez_mysqli extends ezsqlModel implements DatabaseInterface
             );
 
             \array_unshift( $params , $types );
+
             \call_user_func_array( [$stmt , 'bind_param'] , $params );
         }
 

--- a/lib/Database/ez_mysqli.php
+++ b/lib/Database/ez_mysqli.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace ezsql\Database;
 
@@ -11,9 +11,9 @@ use ezsql\DatabaseInterface;
 
 class ez_mysqli extends ezsqlModel implements DatabaseInterface
 {
-    private $return_val = 0;
-    private $is_insert = false;
-    private $shortcutUsed = false;
+    private $return_val      = 0;
+    private $is_insert       = false;
+    private $shortcutUsed    = false;
     private $isTransactional = false;
 
     /**
@@ -34,18 +34,18 @@ class ez_mysqli extends ezsqlModel implements DatabaseInterface
      */
     private $database;
 
-    public function __construct(ConfigInterface $settings = null)
+    public function __construct( ConfigInterface $settings = null )
     {
-        if (empty($settings)) {
-            throw new Exception(\MISSING_CONFIGURATION);
+        if ( empty( $settings ) ) {
+            throw new Exception( \MISSING_CONFIGURATION );
         }
 
         parent::__construct();
         $this->database = $settings;
 
-        if (empty($GLOBALS['ez' . \MYSQLI]))
+        if ( empty( $GLOBALS['ez' . \MYSQLI] ) )
             $GLOBALS['ez' . \MYSQLI] = $this;
-        \setInstance($this);
+        \setInstance( $this );
     } // __construct
 
     public function settings()
@@ -57,31 +57,32 @@ class ez_mysqli extends ezsqlModel implements DatabaseInterface
      * Short hand way to connect to mysql database server and select a mysql
      * database at the same time
      *
-     * @param string $user The database user name
+     * @param string $user     The database user name
      * @param string $password The database users password
-     * @param string $name The name of the database
-     * @param string $host The host name or IP address of the database server.
-     *                       Default is localhost
-     * @param string $charset Encoding of the database
+     * @param string $name     The name of the database
+     * @param string $host     The host name or IP address of the database server.
+     *                         Default is localhost
+     * @param string $charset  Encoding of the database
      * @return boolean
      */
     public function quick_connect(
-        string $user = '',
-        string $password = '',
-        string $name = '',
-        string $host = '',
-        $port = '',
+        string $user = '' ,
+        string $password = '' ,
+        string $name = '' ,
+        string $host = '' ,
+        $port = '' ,
         string $charset = ''
-    ) {
-        $user = empty($user) ? $this->database->getUser() : $user;
-        $password = empty($password) ? $this->database->getPassword() : $password;
-        $name = empty($name) ? $this->database->getName() : $name;
-        $host = empty($host) ? $this->database->getHost() : $host;
-        $port = empty($port) ? $this->database->getPort() : $port;
-        $charset = empty($charset) ? $this->database->getCharset() : $charset;
+    )
+    {
+        $user     = empty( $user ) ? $this->database->getUser() : $user;
+        $password = empty( $password ) ? $this->database->getPassword() : $password;
+        $name     = empty( $name ) ? $this->database->getName() : $name;
+        $host     = empty( $host ) ? $this->database->getHost() : $host;
+        $port     = empty( $port ) ? $this->database->getPort() : $port;
+        $charset  = empty( $charset ) ? $this->database->getCharset() : $charset;
 
-        if (!$this->connect($user, $password, $host, (int) $port, $charset));
-        else if (!$this->select($name, $charset));
+        if ( !$this->connect( $user , $password , $host , (int)$port , $charset ) ) ;
+        else if ( !$this->select( $name , $charset ) ) ;
 
         return $this->_connected;
     } // quick_connect
@@ -89,34 +90,35 @@ class ez_mysqli extends ezsqlModel implements DatabaseInterface
     /**
      * Try to connect to mySQLi database server
      *
-     * @param string $user The database user name
+     * @param string $user     The database user name
      * @param string $password The database users password
-     * @param string $host The host name or IP address of the database server.
-     *                       Default is localhost
-     * @param string $charset The database charset
-     *                      Default is empty string
+     * @param string $host     The host name or IP address of the database server.
+     *                         Default is localhost
+     * @param string $charset  The database charset
+     *                         Default is empty string
      * @return boolean
      */
     public function connect(
-        string $user = '',
-        string $password = '',
-        string $host = '',
-        $port = '',
+        string $user = '' ,
+        string $password = '' ,
+        string $host = '' ,
+        $port = '' ,
         string $charset = ''
-    ) {
+    )
+    {
         $this->_connected = false;
 
-        $user = empty($user) ? $this->database->getUser() : $user;
-        $password = empty($password) ? $this->database->getPassword() : $password;
-        $host = empty($host) ? $this->database->getHost() : $host;
-        $port = empty($port) ? $this->database->getPort() : $port;
-        $charset = empty($charset) ? $this->database->getCharset() : $charset;
+        $user     = empty( $user ) ? $this->database->getUser() : $user;
+        $password = empty( $password ) ? $this->database->getPassword() : $password;
+        $host     = empty( $host ) ? $this->database->getHost() : $host;
+        $port     = empty( $port ) ? $this->database->getPort() : $port;
+        $charset  = empty( $charset ) ? $this->database->getCharset() : $charset;
 
         // Try to establish the server database handle
-        if (!$this->dbh = \mysqli_connect($host, $user, $password, $this->database->getName(),  (int) $port)) {
-            $this->register_error(\FAILED_CONNECTION . ' in ' . __FILE__ . ' on line ' . __LINE__);
+        if ( !$this->dbh = \mysqli_connect( $host , $user , $password , $this->database->getName() , (int)$port ) ) {
+            $this->register_error( \FAILED_CONNECTION . ' in ' . __FILE__ . ' on line ' . __LINE__ );
         } else {
-            \mysqli_set_charset($this->dbh, $charset);
+            \mysqli_set_charset( $this->dbh , $charset );
             $this->_connected = true;
         }
 
@@ -126,40 +128,40 @@ class ez_mysqli extends ezsqlModel implements DatabaseInterface
     /**
      * Try to select a mySQL database
      *
-     * @param string $name The name of the database
+     * @param string $name    The name of the database
      * @param string $charset Encoding of the database
      * @return boolean
      */
-    public function select($name = '', $charset = '')
+    public function select( $name = '' , $charset = '' )
     {
         $this->_connected = false;
-        $name = empty($name) ? $this->database->getName() : $name;
-        if (!$this->dbh) {
+        $name             = empty( $name ) ? $this->database->getName() : $name;
+        if ( !$this->dbh ) {
             // Must have an active database connection
-            $this->register_error(\FAILED_CONNECTION . ' in ' . __FILE__ . ' on line ' . __LINE__);
-        } elseif (!\mysqli_select_db($this->dbh, $name)) {
+            $this->register_error( \FAILED_CONNECTION . ' in ' . __FILE__ . ' on line ' . __LINE__ );
+        } elseif ( !\mysqli_select_db( $this->dbh , $name ) ) {
             // Try to connect to the database
             // Try to get error supplied by mysql if not use our own
-            if (!$str = \mysqli_error($this->dbh)) {
+            if ( !$str = \mysqli_error( $this->dbh ) ) {
                 $str = 'Unexpected error while trying to select database';
             }
-            $this->register_error($str . ' in ' . __FILE__ . ' on line ' . __LINE__);
+            $this->register_error( $str . ' in ' . __FILE__ . ' on line ' . __LINE__ );
         } else {
-            $this->database->setName($name);
-            if ($charset == '') {
+            $this->database->setName( $name );
+            if ( $charset == '' ) {
                 $charset = $this->database->getCharset();
             }
 
-            if ($charset != '') {
-                $encoding = \strtolower(\str_replace('-', '', $charset));
+            if ( $charset != '' ) {
+                $encoding     = \strtolower( \str_replace( '-' , '' , $charset ) );
                 $charsetArray = array();
-                $recordSet = \mysqli_query($this->dbh, 'SHOW CHARACTER SET');
-                while ($row = \mysqli_fetch_array($recordSet, \MYSQLI_ASSOC)) {
+                $recordSet    = \mysqli_query( $this->dbh , 'SHOW CHARACTER SET' );
+                while ( $row = \mysqli_fetch_array( $recordSet , \MYSQLI_ASSOC ) ) {
                     $charsetArray[] = $row['Charset'];
                 }
 
-                if (\in_array($charset, $charsetArray)) {
-                    \mysqli_query($this->dbh, 'SET NAMES \'' . $encoding . '\'');
+                if ( \in_array( $charset , $charsetArray ) ) {
+                    \mysqli_query( $this->dbh , 'SET NAMES \'' . $encoding . '\'' );
                 }
             }
             $this->_connected = true;
@@ -175,9 +177,9 @@ class ez_mysqli extends ezsqlModel implements DatabaseInterface
      * @param string $str
      * @return string
      */
-    public function escape(string $str)
+    public function escape( string $str )
     {
-        return \mysqli_real_escape_string($this->dbh, \stripslashes($str));
+        return \mysqli_real_escape_string( $this->dbh , \stripslashes( $str ) );
     } // escape
 
     /**
@@ -194,45 +196,45 @@ class ez_mysqli extends ezsqlModel implements DatabaseInterface
     /**
      * Helper fetches rows from a prepared result set
      * @param \mysqli_stmt $stmt
-     * @param string $query
+     * @param string       $query
      * @return bool|\mysqli_result
      */
-    private function fetch_prepared_result(&$stmt, $query)
+    private function fetch_prepared_result( &$stmt , $query )
     {
-        if ($stmt instanceof \mysqli_stmt) {
+        if ( $stmt instanceof \mysqli_stmt ) {
             $stmt->store_result();
             $variables = array();
             $is_insert = false;
-            $col_info = array();
-            if (\preg_match("/^(insert|delete|update|replace)\s+/i", $query)) {
-                $this->_affectedRows = \mysqli_stmt_affected_rows($stmt);
+            $col_info  = array();
+            if ( \preg_match( "/^(insert|delete|update|replace)\s+/i" , $query ) ) {
+                $this->_affectedRows = \mysqli_stmt_affected_rows( $stmt );
 
                 // Take note of the insert_id
-                if (\preg_match("/^(insert|replace)\s+/i", $query)) {
+                if ( \preg_match( "/^(insert|replace)\s+/i" , $query ) ) {
                     $this->insert_id = $stmt->insert_id;
                 }
             } else {
                 $this->_affectedRows = $stmt->num_rows;
-                $meta = $stmt->result_metadata();
+                $meta                = $stmt->result_metadata();
 
                 $x = 0;
                 // Take note of column info
-                while ($field = $meta->fetch_field()) {
-                    $col_info[$field->name] = "";
+                while ( $field = $meta->fetch_field() ) {
+                    $col_info[$field->name]  = "";
                     $variables[$field->name] = &$col_info[$field->name];
-                    $this->col_info[$x] = $field;
+                    $this->col_info[$x]      = $field;
                     $x++;
                 }
 
                 // Binds variables to a prepared statement for result storage
-                \call_user_func_array([$stmt, 'bind_result'], $variables);
+                \call_user_func_array( [$stmt , 'bind_result'] , $variables );
 
                 $i = 0;
                 // Store Query Results
-                while ($stmt->fetch()) {
+                while ( $stmt->fetch() ) {
                     // Store results as an objects within main array
                     $resultObject = new \stdClass();
-                    foreach ($variables as $key => $value) {
+                    foreach ( $variables as $key => $value ) {
                         $resultObject->$key = $value;
                     }
                     $this->last_result[$i] = $resultObject;
@@ -241,9 +243,9 @@ class ez_mysqli extends ezsqlModel implements DatabaseInterface
             }
 
             // If there is an error then take note of it..
-            if ($str = $stmt->error) {
+            if ( $str = $stmt->error ) {
                 $is_insert = true;
-                $this->register_error($str);
+                $this->register_error( $str );
 
                 // If debug ALL queries
                 $this->trace || $this->debug_all ? $this->debug() : null;
@@ -254,7 +256,7 @@ class ez_mysqli extends ezsqlModel implements DatabaseInterface
             $return_val = $this->_affectedRows;
 
             // disk caching of queries
-            $this->store_cache($query, $is_insert);
+            $this->store_cache( $query , $is_insert );
 
             // If debug ALL queries
             $this->trace || $this->debug_all ? $this->debug() : null;
@@ -269,43 +271,44 @@ class ez_mysqli extends ezsqlModel implements DatabaseInterface
      * Creates a prepared query, binds the given parameters and returns the result of the executed
      * {@link mysqli_stmt}.
      * @param string $query
-     * @param array $param
+     * @param array  $param
      * @return bool|\mysqli_result
      */
-    public function query_prepared(string $query, array $param = null)
+    public function query_prepared( string $query , array $param = null )
     {
-        $stmt = $this->dbh->prepare($query);
-        if (!$stmt instanceof \mysqli_stmt) {
-            if ($this->isTransactional)
-                throw new \Exception($this->getLast_Error());
+        $stmt = $this->dbh->prepare( $query );
+        if ( !$stmt instanceof \mysqli_stmt ) {
+            if ( $this->isTransactional )
+                throw new \Exception( $this->getLast_Error() );
 
             return false;
         }
 
         $params = [];
-        $types = \array_reduce(
-            $param,
-            function ($string, &$arg) use (&$params) {
-                $params[] = &$arg;
-                if (\is_float($arg))
-                    $string .= 'd';
-                elseif (\is_integer($arg))
-                    $string .= 'i';
-                elseif (\is_string($arg))
-                    $string .= 's';
-                else
-                    $string .= 'b';
+        if ( !empty( $param ) && \is_array( $param ) ) {
+            $types = \array_reduce(
+                $param ,
+                function( $string , &$arg ) use ( &$params ) {
+                    $params[] = &$arg;
+                    if ( \is_float( $arg ) )
+                        $string .= 'd';
+                    elseif ( \is_integer( $arg ) )
+                        $string .= 'i';
+                    elseif ( \is_string( $arg ) )
+                        $string .= 's';
+                    else
+                        $string .= 'b';
 
-                return  $string;
-            },
-            ''
-        );
+                    return $string;
+                } ,
+                ''
+            );
 
-        \array_unshift($params, $types);
+            \array_unshift( $params , $types );
+            \call_user_func_array( [$stmt , 'bind_param'] , $params );
+        }
 
-        \call_user_func_array([$stmt, 'bind_param'], $params);
-
-        $result = ($stmt->execute()) ? $this->fetch_prepared_result($stmt, $query) : false;
+        $result = ($stmt->execute()) ? $this->fetch_prepared_result( $stmt , $query ) : false;
 
         // free and closes a prepared statement
         $stmt->free_result();
@@ -318,19 +321,19 @@ class ez_mysqli extends ezsqlModel implements DatabaseInterface
      * Perform post processing on SQL query call
      *
      * @param string $query
-     * @param mixed $result
+     * @param mixed  $result
      * @return bool|void
      */
-    private function processQueryResult(string $query, $result = null)
+    private function processQueryResult( string $query , $result = null )
     {
         $this->shortcutUsed = false;
 
-        if (!empty($result))
+        if ( !empty( $result ) )
             $this->result = $result;
 
         // If there is an error then take note of it..
-        if ($str = \mysqli_error($this->dbh)) {
-            $this->register_error($str);
+        if ( $str = \mysqli_error( $this->dbh ) ) {
+            $this->register_error( $str );
 
             // If debug ALL queries
             $this->trace || $this->debug_all ? $this->debug() : null;
@@ -339,37 +342,37 @@ class ez_mysqli extends ezsqlModel implements DatabaseInterface
 
         // Query was an insert, delete, update, replace
         $this->is_insert = false;
-        if (\preg_match("/^(insert|delete|update|replace)\s+/i", $query)) {
-            $this->is_insert = true;
-            $this->_affectedRows = \mysqli_affected_rows($this->dbh);
+        if ( \preg_match( "/^(insert|delete|update|replace)\s+/i" , $query ) ) {
+            $this->is_insert     = true;
+            $this->_affectedRows = \mysqli_affected_rows( $this->dbh );
 
             // Take note of the insert_id
-            if (\preg_match("/^(insert|replace)\s+/i", $query)) {
-                $this->insert_id = \mysqli_insert_id($this->dbh);
+            if ( \preg_match( "/^(insert|replace)\s+/i" , $query ) ) {
+                $this->insert_id = \mysqli_insert_id( $this->dbh );
             }
 
             // Return number of rows affected
             $this->return_val = $this->_affectedRows;
         } else {
             // Query was a select
-            if (!\is_numeric($this->result) && !\is_bool($this->result)) {
+            if ( !\is_numeric( $this->result ) && !\is_bool( $this->result ) ) {
 
                 // Take note of column info
                 $i = 0;
-                while ($i < \mysqli_num_fields($this->result)) {
-                    $this->col_info[$i] = \mysqli_fetch_field($this->result);
+                while ( $i < \mysqli_num_fields( $this->result ) ) {
+                    $this->col_info[$i] = \mysqli_fetch_field( $this->result );
                     $i++;
                 }
 
                 // Store Query Results
                 $num_rows = 0;
-                while ($row = \mysqli_fetch_object($this->result)) {
+                while ( $row = \mysqli_fetch_object( $this->result ) ) {
                     // Store results as an objects within main array
                     $this->last_result[$num_rows] = $row;
                     $num_rows++;
                 }
 
-                \mysqli_free_result($this->result);
+                \mysqli_free_result( $this->result );
 
                 // Log number of rows the query returned
                 $this->num_rows = $num_rows;
@@ -384,17 +387,17 @@ class ez_mysqli extends ezsqlModel implements DatabaseInterface
      * Perform mySQL query and try to determine result value
      *
      * @param string $query
-     * @param bool $use_prepare
+     * @param bool   $use_prepare
      * @return bool|mixed
      */
-    public function query(string $query, bool $use_prepare = false)
+    public function query( string $query , bool $use_prepare = false )
     {
         $param = [];
-        if ($use_prepare)
+        if ( $use_prepare )
             $param = $this->prepareValues();
 
         // check for ezQuery placeholder tag and replace tags with proper prepare tag
-        $query = \str_replace(\_TAG, '?', $query);
+        $query = \str_replace( \_TAG , '?' , $query );
 
         // Initialize return
         $this->return_val = 0;
@@ -403,10 +406,10 @@ class ez_mysqli extends ezsqlModel implements DatabaseInterface
         $this->flush();
 
         // For reg expressions
-        $query = \trim($query);
+        $query = \trim( $query );
 
         // Log how the function was called
-        $this->log_query("\$db->query(\"$query\")");
+        $this->log_query( "\$db->query(\"$query\")" );
 
         // Keep track of the last query for debug..
         $this->last_query = $query;
@@ -415,33 +418,33 @@ class ez_mysqli extends ezsqlModel implements DatabaseInterface
         $this->num_queries++;
 
         // Use core file cache function
-        if ($cache = $this->get_cache($query)) {
+        if ( $cache = $this->get_cache( $query ) ) {
             return $cache;
         }
 
         // If there is no existing database connection then try to connect
-        if (!isset($this->dbh) || !$this->dbh) {
-            $this->connect($this->database->getUser(), $this->database->getPassword(), $this->database->getHost());
-            $this->select($this->database->getName());
+        if ( !isset( $this->dbh ) || !$this->dbh ) {
+            $this->connect( $this->database->getUser() , $this->database->getPassword() , $this->database->getHost() );
+            $this->select( $this->database->getName() );
         }
 
         // Perform the query via std mysql_query function..
-        if (!empty($param) && \is_array($param) && ($this->isPrepareOn())) {
+        if ( !empty( $param ) && \is_array( $param ) && ($this->isPrepareOn()) ) {
             $this->shortcutUsed = true;
-            return $this->query_prepared($query, $param);
+            return $this->query_prepared( $query , $param );
         }
 
-        $this->result = \mysqli_query($this->dbh, $query);
+        $this->result = \mysqli_query( $this->dbh , $query );
 
-        if ($this->processQueryResult($query) === false) {
-            if ($this->isTransactional)
-                throw new \Exception($this->getLast_Error());
+        if ( $this->processQueryResult( $query ) === false ) {
+            if ( $this->isTransactional )
+                throw new \Exception( $this->getLast_Error() );
 
             return false;
         }
 
         // disk caching of queries
-        $this->store_cache($query, $this->is_insert);
+        $this->store_cache( $query , $this->is_insert );
 
         // If debug ALL queries
         $this->trace || $this->debug_all ? $this->debug() : null;
@@ -454,8 +457,8 @@ class ez_mysqli extends ezsqlModel implements DatabaseInterface
      */
     public function disconnect()
     {
-        if ($this->dbh) {
-            \mysqli_close($this->dbh);
+        if ( $this->dbh ) {
+            \mysqli_close( $this->dbh );
             $this->_connected = false;
         }
 
@@ -515,7 +518,7 @@ class ez_mysqli extends ezsqlModel implements DatabaseInterface
      */
     public function getInsertId()
     {
-        return \mysqli_insert_id($this->dbh);
+        return \mysqli_insert_id( $this->dbh );
     } // getInsertId
 
     /**
@@ -524,22 +527,22 @@ class ez_mysqli extends ezsqlModel implements DatabaseInterface
     public function beginTransaction()
     {
         /* turn autocommit off */
-        $this->dbh->autocommit(false);
-        $this->dbh->begin_transaction(MYSQLI_TRANS_START_READ_WRITE);
+        $this->dbh->autocommit( false );
+        $this->dbh->begin_transaction( MYSQLI_TRANS_START_READ_WRITE );
         $this->isTransactional = true;
     }
 
     public function commit()
     {
         $this->dbh->commit();
-        $this->dbh->autocommit(true);
+        $this->dbh->autocommit( true );
         $this->isTransactional = false;
     }
 
     public function rollback()
     {
         $this->dbh->rollBack();
-        $this->dbh->autocommit(true);
+        $this->dbh->autocommit( true );
         $this->isTransactional = false;
     }
 } // ez_mysqli

--- a/lib/Database/ez_mysqli.php
+++ b/lib/Database/ez_mysqli.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace ezsql\Database;
 
@@ -11,9 +11,9 @@ use ezsql\DatabaseInterface;
 
 class ez_mysqli extends ezsqlModel implements DatabaseInterface
 {
-    private $return_val      = 0;
-    private $is_insert       = false;
-    private $shortcutUsed    = false;
+    private $return_val = 0;
+    private $is_insert = false;
+    private $shortcutUsed = false;
     private $isTransactional = false;
 
     /**
@@ -34,18 +34,18 @@ class ez_mysqli extends ezsqlModel implements DatabaseInterface
      */
     private $database;
 
-    public function __construct( ConfigInterface $settings = null )
+    public function __construct(ConfigInterface $settings = null)
     {
-        if ( empty( $settings ) ) {
-            throw new Exception( \MISSING_CONFIGURATION );
+        if (empty($settings)) {
+            throw new Exception(\MISSING_CONFIGURATION);
         }
 
         parent::__construct();
         $this->database = $settings;
 
-        if ( empty( $GLOBALS['ez' . \MYSQLI] ) )
+        if (empty($GLOBALS['ez' . \MYSQLI]))
             $GLOBALS['ez' . \MYSQLI] = $this;
-        \setInstance( $this );
+        \setInstance($this);
     } // __construct
 
     public function settings()
@@ -57,32 +57,31 @@ class ez_mysqli extends ezsqlModel implements DatabaseInterface
      * Short hand way to connect to mysql database server and select a mysql
      * database at the same time
      *
-     * @param string $user     The database user name
+     * @param string $user The database user name
      * @param string $password The database users password
-     * @param string $name     The name of the database
-     * @param string $host     The host name or IP address of the database server.
-     *                         Default is localhost
-     * @param string $charset  Encoding of the database
+     * @param string $name The name of the database
+     * @param string $host The host name or IP address of the database server.
+     *                       Default is localhost
+     * @param string $charset Encoding of the database
      * @return boolean
      */
     public function quick_connect(
-        string $user = '' ,
-        string $password = '' ,
-        string $name = '' ,
-        string $host = '' ,
-        $port = '' ,
+        string $user = '',
+        string $password = '',
+        string $name = '',
+        string $host = '',
+        $port = '',
         string $charset = ''
-    )
-    {
-        $user     = empty( $user ) ? $this->database->getUser() : $user;
-        $password = empty( $password ) ? $this->database->getPassword() : $password;
-        $name     = empty( $name ) ? $this->database->getName() : $name;
-        $host     = empty( $host ) ? $this->database->getHost() : $host;
-        $port     = empty( $port ) ? $this->database->getPort() : $port;
-        $charset  = empty( $charset ) ? $this->database->getCharset() : $charset;
+    ) {
+        $user = empty($user) ? $this->database->getUser() : $user;
+        $password = empty($password) ? $this->database->getPassword() : $password;
+        $name = empty($name) ? $this->database->getName() : $name;
+        $host = empty($host) ? $this->database->getHost() : $host;
+        $port = empty($port) ? $this->database->getPort() : $port;
+        $charset = empty($charset) ? $this->database->getCharset() : $charset;
 
-        if ( !$this->connect( $user , $password , $host , (int)$port , $charset ) ) ;
-        else if ( !$this->select( $name , $charset ) ) ;
+        if (!$this->connect($user, $password, $host, (int) $port, $charset));
+        else if (!$this->select($name, $charset));
 
         return $this->_connected;
     } // quick_connect
@@ -90,35 +89,34 @@ class ez_mysqli extends ezsqlModel implements DatabaseInterface
     /**
      * Try to connect to mySQLi database server
      *
-     * @param string $user     The database user name
+     * @param string $user The database user name
      * @param string $password The database users password
-     * @param string $host     The host name or IP address of the database server.
-     *                         Default is localhost
-     * @param string $charset  The database charset
-     *                         Default is empty string
+     * @param string $host The host name or IP address of the database server.
+     *                       Default is localhost
+     * @param string $charset The database charset
+     *                      Default is empty string
      * @return boolean
      */
     public function connect(
-        string $user = '' ,
-        string $password = '' ,
-        string $host = '' ,
-        $port = '' ,
+        string $user = '',
+        string $password = '',
+        string $host = '',
+        $port = '',
         string $charset = ''
-    )
-    {
+    ) {
         $this->_connected = false;
 
-        $user     = empty( $user ) ? $this->database->getUser() : $user;
-        $password = empty( $password ) ? $this->database->getPassword() : $password;
-        $host     = empty( $host ) ? $this->database->getHost() : $host;
-        $port     = empty( $port ) ? $this->database->getPort() : $port;
-        $charset  = empty( $charset ) ? $this->database->getCharset() : $charset;
+        $user = empty($user) ? $this->database->getUser() : $user;
+        $password = empty($password) ? $this->database->getPassword() : $password;
+        $host = empty($host) ? $this->database->getHost() : $host;
+        $port = empty($port) ? $this->database->getPort() : $port;
+        $charset = empty($charset) ? $this->database->getCharset() : $charset;
 
         // Try to establish the server database handle
-        if ( !$this->dbh = \mysqli_connect( $host , $user , $password , $this->database->getName() , (int)$port ) ) {
-            $this->register_error( \FAILED_CONNECTION . ' in ' . __FILE__ . ' on line ' . __LINE__ );
+        if (!$this->dbh = \mysqli_connect($host, $user, $password, $this->database->getName(),  (int) $port)) {
+            $this->register_error(\FAILED_CONNECTION . ' in ' . __FILE__ . ' on line ' . __LINE__);
         } else {
-            \mysqli_set_charset( $this->dbh , $charset );
+            \mysqli_set_charset($this->dbh, $charset);
             $this->_connected = true;
         }
 
@@ -128,40 +126,40 @@ class ez_mysqli extends ezsqlModel implements DatabaseInterface
     /**
      * Try to select a mySQL database
      *
-     * @param string $name    The name of the database
+     * @param string $name The name of the database
      * @param string $charset Encoding of the database
      * @return boolean
      */
-    public function select( $name = '' , $charset = '' )
+    public function select($name = '', $charset = '')
     {
         $this->_connected = false;
-        $name             = empty( $name ) ? $this->database->getName() : $name;
-        if ( !$this->dbh ) {
+        $name = empty($name) ? $this->database->getName() : $name;
+        if (!$this->dbh) {
             // Must have an active database connection
-            $this->register_error( \FAILED_CONNECTION . ' in ' . __FILE__ . ' on line ' . __LINE__ );
-        } elseif ( !\mysqli_select_db( $this->dbh , $name ) ) {
+            $this->register_error(\FAILED_CONNECTION . ' in ' . __FILE__ . ' on line ' . __LINE__);
+        } elseif (!\mysqli_select_db($this->dbh, $name)) {
             // Try to connect to the database
             // Try to get error supplied by mysql if not use our own
-            if ( !$str = \mysqli_error( $this->dbh ) ) {
+            if (!$str = \mysqli_error($this->dbh)) {
                 $str = 'Unexpected error while trying to select database';
             }
-            $this->register_error( $str . ' in ' . __FILE__ . ' on line ' . __LINE__ );
+            $this->register_error($str . ' in ' . __FILE__ . ' on line ' . __LINE__);
         } else {
-            $this->database->setName( $name );
-            if ( $charset == '' ) {
+            $this->database->setName($name);
+            if ($charset == '') {
                 $charset = $this->database->getCharset();
             }
 
-            if ( $charset != '' ) {
-                $encoding     = \strtolower( \str_replace( '-' , '' , $charset ) );
+            if ($charset != '') {
+                $encoding = \strtolower(\str_replace('-', '', $charset));
                 $charsetArray = array();
-                $recordSet    = \mysqli_query( $this->dbh , 'SHOW CHARACTER SET' );
-                while ( $row = \mysqli_fetch_array( $recordSet , \MYSQLI_ASSOC ) ) {
+                $recordSet = \mysqli_query($this->dbh, 'SHOW CHARACTER SET');
+                while ($row = \mysqli_fetch_array($recordSet, \MYSQLI_ASSOC)) {
                     $charsetArray[] = $row['Charset'];
                 }
 
-                if ( \in_array( $charset , $charsetArray ) ) {
-                    \mysqli_query( $this->dbh , 'SET NAMES \'' . $encoding . '\'' );
+                if (\in_array($charset, $charsetArray)) {
+                    \mysqli_query($this->dbh, 'SET NAMES \'' . $encoding . '\'');
                 }
             }
             $this->_connected = true;
@@ -177,9 +175,9 @@ class ez_mysqli extends ezsqlModel implements DatabaseInterface
      * @param string $str
      * @return string
      */
-    public function escape( string $str )
+    public function escape(string $str)
     {
-        return \mysqli_real_escape_string( $this->dbh , \stripslashes( $str ) );
+        return \mysqli_real_escape_string($this->dbh, \stripslashes($str));
     } // escape
 
     /**
@@ -196,45 +194,45 @@ class ez_mysqli extends ezsqlModel implements DatabaseInterface
     /**
      * Helper fetches rows from a prepared result set
      * @param \mysqli_stmt $stmt
-     * @param string       $query
+     * @param string $query
      * @return bool|\mysqli_result
      */
-    private function fetch_prepared_result( &$stmt , $query )
+    private function fetch_prepared_result(&$stmt, $query)
     {
-        if ( $stmt instanceof \mysqli_stmt ) {
+        if ($stmt instanceof \mysqli_stmt) {
             $stmt->store_result();
             $variables = array();
             $is_insert = false;
-            $col_info  = array();
-            if ( \preg_match( "/^(insert|delete|update|replace)\s+/i" , $query ) ) {
-                $this->_affectedRows = \mysqli_stmt_affected_rows( $stmt );
+            $col_info = array();
+            if (\preg_match("/^(insert|delete|update|replace)\s+/i", $query)) {
+                $this->_affectedRows = \mysqli_stmt_affected_rows($stmt);
 
                 // Take note of the insert_id
-                if ( \preg_match( "/^(insert|replace)\s+/i" , $query ) ) {
+                if (\preg_match("/^(insert|replace)\s+/i", $query)) {
                     $this->insert_id = $stmt->insert_id;
                 }
             } else {
                 $this->_affectedRows = $stmt->num_rows;
-                $meta                = $stmt->result_metadata();
+                $meta = $stmt->result_metadata();
 
                 $x = 0;
                 // Take note of column info
-                while ( $field = $meta->fetch_field() ) {
-                    $col_info[$field->name]  = "";
+                while ($field = $meta->fetch_field()) {
+                    $col_info[$field->name] = "";
                     $variables[$field->name] = &$col_info[$field->name];
-                    $this->col_info[$x]      = $field;
+                    $this->col_info[$x] = $field;
                     $x++;
                 }
 
                 // Binds variables to a prepared statement for result storage
-                \call_user_func_array( [$stmt , 'bind_result'] , $variables );
+                \call_user_func_array([$stmt, 'bind_result'], $variables);
 
                 $i = 0;
                 // Store Query Results
-                while ( $stmt->fetch() ) {
+                while ($stmt->fetch()) {
                     // Store results as an objects within main array
                     $resultObject = new \stdClass();
-                    foreach ( $variables as $key => $value ) {
+                    foreach ($variables as $key => $value) {
                         $resultObject->$key = $value;
                     }
                     $this->last_result[$i] = $resultObject;
@@ -243,9 +241,9 @@ class ez_mysqli extends ezsqlModel implements DatabaseInterface
             }
 
             // If there is an error then take note of it..
-            if ( $str = $stmt->error ) {
+            if ($str = $stmt->error) {
                 $is_insert = true;
-                $this->register_error( $str );
+                $this->register_error($str);
 
                 // If debug ALL queries
                 $this->trace || $this->debug_all ? $this->debug() : null;
@@ -256,7 +254,7 @@ class ez_mysqli extends ezsqlModel implements DatabaseInterface
             $return_val = $this->_affectedRows;
 
             // disk caching of queries
-            $this->store_cache( $query , $is_insert );
+            $this->store_cache($query, $is_insert);
 
             // If debug ALL queries
             $this->trace || $this->debug_all ? $this->debug() : null;
@@ -271,21 +269,21 @@ class ez_mysqli extends ezsqlModel implements DatabaseInterface
      * Creates a prepared query, binds the given parameters and returns the result of the executed
      * {@link mysqli_stmt}.
      * @param string $query
-     * @param array  $param
+     * @param array $param
      * @return bool|\mysqli_result
      */
-    public function query_prepared( string $query , array $param = null )
+    public function query_prepared(string $query, array $param = null)
     {
-        $stmt = $this->dbh->prepare( $query );
-        if ( !$stmt instanceof \mysqli_stmt ) {
-            if ( $this->isTransactional )
-                throw new \Exception( $this->getLast_Error() );
+        $stmt = $this->dbh->prepare($query);
+        if (!$stmt instanceof \mysqli_stmt) {
+            if ($this->isTransactional)
+                throw new \Exception($this->getLast_Error());
 
             return false;
         }
 
         $params = [];
-        if ( !empty( $param ) && \is_array( $param ) ) {
+        if ( !empty( $param ) && \is_array( $param )) {
             $types = \array_reduce(
                 $param ,
                 function( $string , &$arg ) use ( &$params ) {
@@ -308,7 +306,7 @@ class ez_mysqli extends ezsqlModel implements DatabaseInterface
             \call_user_func_array( [$stmt , 'bind_param'] , $params );
         }
 
-        $result = ($stmt->execute()) ? $this->fetch_prepared_result( $stmt , $query ) : false;
+        $result = ($stmt->execute()) ? $this->fetch_prepared_result($stmt, $query) : false;
 
         // free and closes a prepared statement
         $stmt->free_result();
@@ -321,19 +319,19 @@ class ez_mysqli extends ezsqlModel implements DatabaseInterface
      * Perform post processing on SQL query call
      *
      * @param string $query
-     * @param mixed  $result
+     * @param mixed $result
      * @return bool|void
      */
-    private function processQueryResult( string $query , $result = null )
+    private function processQueryResult(string $query, $result = null)
     {
         $this->shortcutUsed = false;
 
-        if ( !empty( $result ) )
+        if (!empty($result))
             $this->result = $result;
 
         // If there is an error then take note of it..
-        if ( $str = \mysqli_error( $this->dbh ) ) {
-            $this->register_error( $str );
+        if ($str = \mysqli_error($this->dbh)) {
+            $this->register_error($str);
 
             // If debug ALL queries
             $this->trace || $this->debug_all ? $this->debug() : null;
@@ -342,37 +340,37 @@ class ez_mysqli extends ezsqlModel implements DatabaseInterface
 
         // Query was an insert, delete, update, replace
         $this->is_insert = false;
-        if ( \preg_match( "/^(insert|delete|update|replace)\s+/i" , $query ) ) {
-            $this->is_insert     = true;
-            $this->_affectedRows = \mysqli_affected_rows( $this->dbh );
+        if (\preg_match("/^(insert|delete|update|replace)\s+/i", $query)) {
+            $this->is_insert = true;
+            $this->_affectedRows = \mysqli_affected_rows($this->dbh);
 
             // Take note of the insert_id
-            if ( \preg_match( "/^(insert|replace)\s+/i" , $query ) ) {
-                $this->insert_id = \mysqli_insert_id( $this->dbh );
+            if (\preg_match("/^(insert|replace)\s+/i", $query)) {
+                $this->insert_id = \mysqli_insert_id($this->dbh);
             }
 
             // Return number of rows affected
             $this->return_val = $this->_affectedRows;
         } else {
             // Query was a select
-            if ( !\is_numeric( $this->result ) && !\is_bool( $this->result ) ) {
+            if (!\is_numeric($this->result) && !\is_bool($this->result)) {
 
                 // Take note of column info
                 $i = 0;
-                while ( $i < \mysqli_num_fields( $this->result ) ) {
-                    $this->col_info[$i] = \mysqli_fetch_field( $this->result );
+                while ($i < \mysqli_num_fields($this->result)) {
+                    $this->col_info[$i] = \mysqli_fetch_field($this->result);
                     $i++;
                 }
 
                 // Store Query Results
                 $num_rows = 0;
-                while ( $row = \mysqli_fetch_object( $this->result ) ) {
+                while ($row = \mysqli_fetch_object($this->result)) {
                     // Store results as an objects within main array
                     $this->last_result[$num_rows] = $row;
                     $num_rows++;
                 }
 
-                \mysqli_free_result( $this->result );
+                \mysqli_free_result($this->result);
 
                 // Log number of rows the query returned
                 $this->num_rows = $num_rows;
@@ -387,17 +385,17 @@ class ez_mysqli extends ezsqlModel implements DatabaseInterface
      * Perform mySQL query and try to determine result value
      *
      * @param string $query
-     * @param bool   $use_prepare
+     * @param bool $use_prepare
      * @return bool|mixed
      */
-    public function query( string $query , bool $use_prepare = false )
+    public function query(string $query, bool $use_prepare = false)
     {
         $param = [];
-        if ( $use_prepare )
+        if ($use_prepare)
             $param = $this->prepareValues();
 
         // check for ezQuery placeholder tag and replace tags with proper prepare tag
-        $query = \str_replace( \_TAG , '?' , $query );
+        $query = \str_replace(\_TAG, '?', $query);
 
         // Initialize return
         $this->return_val = 0;
@@ -406,10 +404,10 @@ class ez_mysqli extends ezsqlModel implements DatabaseInterface
         $this->flush();
 
         // For reg expressions
-        $query = \trim( $query );
+        $query = \trim($query);
 
         // Log how the function was called
-        $this->log_query( "\$db->query(\"$query\")" );
+        $this->log_query("\$db->query(\"$query\")");
 
         // Keep track of the last query for debug..
         $this->last_query = $query;
@@ -418,33 +416,33 @@ class ez_mysqli extends ezsqlModel implements DatabaseInterface
         $this->num_queries++;
 
         // Use core file cache function
-        if ( $cache = $this->get_cache( $query ) ) {
+        if ($cache = $this->get_cache($query)) {
             return $cache;
         }
 
         // If there is no existing database connection then try to connect
-        if ( !isset( $this->dbh ) || !$this->dbh ) {
-            $this->connect( $this->database->getUser() , $this->database->getPassword() , $this->database->getHost() );
-            $this->select( $this->database->getName() );
+        if (!isset($this->dbh) || !$this->dbh) {
+            $this->connect($this->database->getUser(), $this->database->getPassword(), $this->database->getHost());
+            $this->select($this->database->getName());
         }
 
         // Perform the query via std mysql_query function..
-        if ( !empty( $param ) && \is_array( $param ) && ($this->isPrepareOn()) ) {
+        if (!empty($param) && \is_array($param) && ($this->isPrepareOn())) {
             $this->shortcutUsed = true;
-            return $this->query_prepared( $query , $param );
+            return $this->query_prepared($query, $param);
         }
 
-        $this->result = \mysqli_query( $this->dbh , $query );
+        $this->result = \mysqli_query($this->dbh, $query);
 
-        if ( $this->processQueryResult( $query ) === false ) {
-            if ( $this->isTransactional )
-                throw new \Exception( $this->getLast_Error() );
+        if ($this->processQueryResult($query) === false) {
+            if ($this->isTransactional)
+                throw new \Exception($this->getLast_Error());
 
             return false;
         }
 
         // disk caching of queries
-        $this->store_cache( $query , $this->is_insert );
+        $this->store_cache($query, $this->is_insert);
 
         // If debug ALL queries
         $this->trace || $this->debug_all ? $this->debug() : null;
@@ -457,8 +455,8 @@ class ez_mysqli extends ezsqlModel implements DatabaseInterface
      */
     public function disconnect()
     {
-        if ( $this->dbh ) {
-            \mysqli_close( $this->dbh );
+        if ($this->dbh) {
+            \mysqli_close($this->dbh);
             $this->_connected = false;
         }
 
@@ -518,7 +516,7 @@ class ez_mysqli extends ezsqlModel implements DatabaseInterface
      */
     public function getInsertId()
     {
-        return \mysqli_insert_id( $this->dbh );
+        return \mysqli_insert_id($this->dbh);
     } // getInsertId
 
     /**
@@ -527,22 +525,22 @@ class ez_mysqli extends ezsqlModel implements DatabaseInterface
     public function beginTransaction()
     {
         /* turn autocommit off */
-        $this->dbh->autocommit( false );
-        $this->dbh->begin_transaction( MYSQLI_TRANS_START_READ_WRITE );
+        $this->dbh->autocommit(false);
+        $this->dbh->begin_transaction(MYSQLI_TRANS_START_READ_WRITE);
         $this->isTransactional = true;
     }
 
     public function commit()
     {
         $this->dbh->commit();
-        $this->dbh->autocommit( true );
+        $this->dbh->autocommit(true);
         $this->isTransactional = false;
     }
 
     public function rollback()
     {
         $this->dbh->rollBack();
-        $this->dbh->autocommit( true );
+        $this->dbh->autocommit(true);
         $this->isTransactional = false;
     }
 } // ez_mysqli

--- a/tests/mysqli/mysqliTest.php
+++ b/tests/mysqli/mysqliTest.php
@@ -611,6 +611,15 @@ class mysqliTest extends EZTestCase
             $this->assertEquals(1200.50, $row->prepare_price);
         }
 
+
+        $this->object->query_prepared('SELECT id, prepare_key, prepare_price FROM prepare_test WHERE id = 99', []);
+        $query = $this->object->queryResult();
+        foreach ($query as $row) {
+            $this->assertEquals(99, $row->id);
+            $this->assertEquals('all good', $row->prepare_key);
+            $this->assertEquals(1200.50, $row->prepare_price);
+        }
+
         $this->object->drop('prepare_test');
     }
 


### PR DESCRIPTION
When we send a prepared_query with an empty array we get an error.

issue #190

To Reproduce
$db->query_prepared( 'select id from table' , []);

Expected behavior
Return result without errors

Environment:
EZSQL Version : 4.0.10
PHP Version: 7.3
SQL Driver: mysql

Changes: 
* if statment added in ez_mysqi.php
* test added in mysqliTest.php