### PR TITLE
PHPUnit Tests

### DIFF
--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -45,7 +45,7 @@ class ConfigTest extends EZTestCase
         }
 
         $this->expectException(\Exception::class);
-        $this->expectExceptionMessageRegExp('/[Missing configuration details to connect to database]/');
+        $this->expectExceptionMessageMatches('/[Missing configuration details to connect to database]/');
         $settings = Config::initialize('mysqli', [self::TEST_DB_USER, self::TEST_DB_PASSWORD]);
     }
 
@@ -88,7 +88,7 @@ class ConfigTest extends EZTestCase
 
         $dsn = 'mysql:host=' . self::TEST_DB_HOST . ';dbname=' . self::TEST_DB_NAME . ';port=3306';
         $this->expectException(\Exception::class);
-        $this->expectExceptionMessageRegExp('/[Missing configuration details to connect to database]/');
+        $this->expectExceptionMessageMatches('/[Missing configuration details to connect to database]/');
         $settings = Config::initialize('pdo', [$dsn]);
     }
 
@@ -102,7 +102,7 @@ class ConfigTest extends EZTestCase
 
         $dsn = 'mysql:host=' . self::TEST_DB_HOST . ';dbname=' . self::TEST_DB_NAME . ';port=3306';
         $this->expectException(\Exception::class);
-        $this->expectExceptionMessageRegExp('/[does not exist]/');
+        $this->expectExceptionMessageMatches('/[does not exist]/');
         $settings = new Config('pdo', [$dsn, self::TEST_DB_USER, self::TEST_DB_PASSWORD]);
         $settings->getNotAnProperty();
     }
@@ -145,7 +145,7 @@ class ConfigTest extends EZTestCase
         }
 
         $this->expectException(\Exception::class);
-        $this->expectExceptionMessageRegExp('/[Missing configuration details to connect to database]/');
+        $this->expectExceptionMessageMatches('/[Missing configuration details to connect to database]/');
         $settings = Config::initialize('pgsql', [self::TEST_DB_USER, self::TEST_DB_PASSWORD]);
     }
 
@@ -185,7 +185,7 @@ class ConfigTest extends EZTestCase
         }
 
         $this->expectException(\Exception::class);
-        $this->expectExceptionMessageRegExp('/[Missing configuration details to connect to database]/');
+        $this->expectExceptionMessageMatches('/[Missing configuration details to connect to database]/');
         $settings = new Config('sqlsrv', [self::TEST_DB_USER, self::TEST_DB_PASSWORD]);
     }
 
@@ -224,21 +224,21 @@ class ConfigTest extends EZTestCase
         }
 
         $this->expectException(\Exception::class);
-        $this->expectExceptionMessageRegExp('/[Missing configuration details to connect to database]/');
+        $this->expectExceptionMessageMatches('/[Missing configuration details to connect to database]/');
         $settings = new Config('sqlite3', [self::TEST_SQLITE_DB_DIR]);
     }
 
     public function test_construct()
     {
         $this->expectException(\Exception::class);
-        $this->expectExceptionMessageRegExp('/[Missing configuration details to connect to database]/');
+        $this->expectExceptionMessageMatches('/[Missing configuration details to connect to database]/');
         $settings = new Config('', [self::TEST_DB_USER, self::TEST_DB_PASSWORD, self::TEST_DB_NAME]);
     }
 
     public function test_constructArgs()
     {
         $this->expectException(\Exception::class);
-        $this->expectExceptionMessageRegExp('/[Missing configuration details to connect to database]/');
+        $this->expectExceptionMessageMatches('/[Missing configuration details to connect to database]/');
         $settings = new Config('mysqli');
     }
 }

--- a/tests/DInjectorTest.php
+++ b/tests/DInjectorTest.php
@@ -52,7 +52,7 @@ class DInjectorTest extends EZTestCase
     {
         $container = new DInjector();
         $this->expectException(ContainerException::class);
-        $this->expectExceptionMessageRegExp('/[is not instantiable]/');
+        $this->expectExceptionMessageMatches('/[is not instantiable]/');
         $baz = $container->autoWire('ezsql\Tests\Baz');
     }
 
@@ -70,7 +70,7 @@ class DInjectorTest extends EZTestCase
     {
         $container = new DInjector();
         $this->expectException(NotFoundException::class);
-        $this->expectExceptionMessageRegExp('/[does not exists]/');
+        $this->expectExceptionMessageMatches('/[does not exists]/');
         $baz = $container->get('Baz');
     }
 }

--- a/tests/DatabaseTest.php
+++ b/tests/DatabaseTest.php
@@ -105,7 +105,7 @@ class DatabaseTest extends EZTestCase
     public function testInitialize_Error()
     {
         $this->expectException(\Exception::class);
-        $this->expectExceptionMessageRegExp('/[Missing configuration details]/');
+        $this->expectExceptionMessageMatches('/[Missing configuration details]/');
         $mysqli = Database::initialize('', [self::TEST_DB_USER, self::TEST_DB_PASSWORD, self::TEST_DB_NAME]);
     }
 }

--- a/tests/ezSchemaTest.php
+++ b/tests/ezSchemaTest.php
@@ -104,7 +104,7 @@ class ezSchemaTest extends EZTestCase
         $this->assertFalse(column('id', INTR, 32, AUTO, PRIMARY));
         $db = mysqlInstance([self::TEST_DB_USER, self::TEST_DB_PASSWORD, self::TEST_DB_NAME]);
         $this->expectException(\Exception::class);
-        $this->expectExceptionMessageRegExp('/[does not exist]/');
+        $this->expectExceptionMessageMatches('/[does not exist]/');
         $this->assertNull(column('id', 'DOS', 32));
     }
 

--- a/tests/ezsqlModelTest.php
+++ b/tests/ezsqlModelTest.php
@@ -43,7 +43,7 @@ class ezsqlModelTest extends EZTestCase
     public function testGetNotProperty()
     {
         $this->expectException(\Exception::class);
-        $this->expectExceptionMessageRegExp('/does not exist/');
+        $this->expectExceptionMessageMatches('/does not exist/');
         $res = $this->object->getNotProperty();
     }
 

--- a/tests/mysqli/mysqliTest.php
+++ b/tests/mysqli/mysqliTest.php
@@ -616,7 +616,7 @@ class mysqliTest extends EZTestCase
 
     public function test__construct_Error()
     {
-        $this->expectExceptionMessageRegExp('/[Missing configuration details]/');
+        $this->expectExceptionMessageMatches('/[Missing configuration details]/');
         $this->assertNull(new ez_mysqli());
     }
 

--- a/tests/pdo/pdo_mysqlTest.php
+++ b/tests/pdo/pdo_mysqlTest.php
@@ -293,9 +293,9 @@ class pdo_mysqlTest extends EZTestCase
         $this->object->insert('unit_test', array('id' => '2', 'test_key' => 'testing 2'));
         $this->object->insert('unit_test', array('id' => '3', 'test_key' => 'testing 3'));
         $this->object->query('CREATE TABLE unit_test_child(child_id integer, child_test_key varchar(50), parent_id integer, PRIMARY KEY (child_id))');
-        $this->object->insert('unit_test', array('child_id' => '1', 'child_test_key' => 'testing child 1', 'parent_id' => '3'));
-        $this->object->insert('unit_test', array('child_id' => '2', 'child_test_key' => 'testing child 2', 'parent_id' => '2'));
-        $this->object->insert('unit_test', array('child_id' => '3', 'child_test_key' => 'testing child 3', 'parent_id' => '1'));
+        $this->object->insert('unit_test_child', array('child_id' => '1', 'child_test_key' => 'testing child 1', 'parent_id' => '3'));
+        $this->object->insert('unit_test_child', array('child_id' => '2', 'child_test_key' => 'testing child 2', 'parent_id' => '2'));
+        $this->object->insert('unit_test_child', array('child_id' => '3', 'child_test_key' => 'testing child 3', 'parent_id' => '1'));
 
         $result = $this->object->selecting('unit_test_child', '*', leftJoin('unit_test_child', 'unit_test', 'parent_id', 'id'));
         $i = 1;
@@ -316,8 +316,8 @@ class pdo_mysqlTest extends EZTestCase
             --$o;
         }
 
-        $this->assertEquals(0, $this->object->query('DROP TABLE unit_test'));
-        $this->assertEquals(0, $this->object->query('DROP TABLE unit_test_child'));
+        $this->assertEquals(0, $this->object->drop('unit_test'));
+        $this->assertEquals(0, $this->object->drop('unit_test_child'));
     }
 
     public function testBeginTransactionCommit()
@@ -443,7 +443,7 @@ class pdo_mysqlTest extends EZTestCase
 
     public function test__Construct_Error()
     {
-        $this->expectExceptionMessageRegExp('/[Missing configuration details]/');
+        $this->expectExceptionMessageMatches('/[Missing configuration details]/');
         $this->assertNull(new ez_pdo());
     }
 

--- a/tests/pdo/pdo_pgsqlTest.php
+++ b/tests/pdo/pdo_pgsqlTest.php
@@ -215,9 +215,9 @@ class pdo_pgsqlTest extends EZTestCase
         $this->object->insert('unit_test', array('id' => '2', 'test_key' => 'testing 2'));
         $this->object->insert('unit_test', array('id' => '3', 'test_key' => 'testing 3'));
         $this->object->query('CREATE TABLE unit_test_child(child_id integer, child_test_key varchar(50), parent_id integer, PRIMARY KEY (child_id))');
-        $this->object->insert('unit_test', array('child_id' => '1', 'child_test_key' => 'testing child 1', 'parent_id' => '3'));
-        $this->object->insert('unit_test', array('child_id' => '2', 'child_test_key' => 'testing child 2', 'parent_id' => '2'));
-        $this->object->insert('unit_test', array('child_id' => '3', 'child_test_key' => 'testing child 3', 'parent_id' => '1'));
+        $this->object->insert('unit_test_child', array('child_id' => '1', 'child_test_key' => 'testing child 1', 'parent_id' => '3'));
+        $this->object->insert('unit_test_child', array('child_id' => '2', 'child_test_key' => 'testing child 2', 'parent_id' => '2'));
+        $this->object->insert('unit_test_child', array('child_id' => '3', 'child_test_key' => 'testing child 3', 'parent_id' => '1'));
 
         $result = $this->object->selecting('unit_test_child', '*', leftJoin('unit_test_child', 'unit_test', 'parent_id', 'id'));
         $i = 1;

--- a/tests/pdo/pdo_sqliteTest.php
+++ b/tests/pdo/pdo_sqliteTest.php
@@ -244,9 +244,9 @@ class pdo_sqliteTest extends EZTestCase
         $this->object->insert('unit_test', array('id' => '2', 'test_key' => 'testing 2'));
         $this->object->insert('unit_test', array('id' => '3', 'test_key' => 'testing 3'));
         $this->object->query('CREATE TABLE unit_test_child(child_id integer, child_test_key varchar(50), parent_id integer, PRIMARY KEY (child_id))');
-        $this->object->insert('unit_test', array('child_id' => '1', 'child_test_key' => 'testing child 1', 'parent_id' => '3'));
-        $this->object->insert('unit_test', array('child_id' => '2', 'child_test_key' => 'testing child 2', 'parent_id' => '2'));
-        $this->object->insert('unit_test', array('child_id' => '3', 'child_test_key' => 'testing child 3', 'parent_id' => '1'));
+        $this->object->insert('unit_test_child', array('child_id' => '1', 'child_test_key' => 'testing child 1', 'parent_id' => '3'));
+        $this->object->insert('unit_test_child', array('child_id' => '2', 'child_test_key' => 'testing child 2', 'parent_id' => '2'));
+        $this->object->insert('unit_test_child', array('child_id' => '3', 'child_test_key' => 'testing child 3', 'parent_id' => '1'));
 
         $result = $this->object->selecting('unit_test_child', '*', leftJoin('unit_test_child', 'unit_test', 'parent_id', 'id'));
         $i = 1;

--- a/tests/pdo/pdo_sqlsrvTest.php
+++ b/tests/pdo/pdo_sqlsrvTest.php
@@ -219,9 +219,9 @@ class pdo_sqlsrvTest extends EZTestCase
         $this->object->insert('unit_test', array('id' => '2', 'test_key' => 'testing 2'));
         $this->object->insert('unit_test', array('id' => '3', 'test_key' => 'testing 3'));
         $this->object->query('CREATE TABLE unit_test_child(child_id integer, child_test_key varchar(50), parent_id integer, PRIMARY KEY (child_id))');
-        $this->object->insert('unit_test', array('child_id' => '1', 'child_test_key' => 'testing child 1', 'parent_id' => '3'));
-        $this->object->insert('unit_test', array('child_id' => '2', 'child_test_key' => 'testing child 2', 'parent_id' => '2'));
-        $this->object->insert('unit_test', array('child_id' => '3', 'child_test_key' => 'testing child 3', 'parent_id' => '1'));
+        $this->object->insert('unit_test_child', array('child_id' => '1', 'child_test_key' => 'testing child 1', 'parent_id' => '3'));
+        $this->object->insert('unit_test_child', array('child_id' => '2', 'child_test_key' => 'testing child 2', 'parent_id' => '2'));
+        $this->object->insert('unit_test_child', array('child_id' => '3', 'child_test_key' => 'testing child 3', 'parent_id' => '1'));
 
         $result = $this->object->selecting('unit_test_child', '*', leftJoin('unit_test_child', 'unit_test', 'parent_id', 'id'));
         $i = 1;


### PR DESCRIPTION
Resolves #200 and also fixed phpunit error `expectExceptionMessageRegExp() is deprecated in PHPUnit 8 and will be removed in PHPUnit 9. Use expectExceptionMessageMatches() instead.`