### PR TITLE
Fix Error: Uncaught TypeError: Argument 1 passed

### DIFF
--- a/lib/ezQuery.php
+++ b/lib/ezQuery.php
@@ -622,7 +622,7 @@ class ezQuery implements ezQueryInterface
         $sql = "UPDATE $table SET ";
 
         foreach ($keyValue as $key => $val) {
-            if (\strtolower($val) == 'null') {
+            if (is_null($val) || \strtolower($val) == 'null') {
                 $sql .= "$key = NULL, ";
             } elseif (\in_array(\strtolower($val), array('current_timestamp()', 'date()', 'now()'))) {
                 $sql .= "$key = CURRENT_TIMESTAMP(), ";


### PR DESCRIPTION
Code:
```
$data   = [
  'name'            => $_GET['name'],
  'fax'             => NULL,
  'updated_on'      => date('Y-m-d H:i:s'),
];
$db->update('restaurant', $data, ['id', '=', 12]);
```

Error:
`Fatal error: Uncaught TypeError: Argument 1 passed to ezsql\Database\ez_pdo::escape() must be of the type string, null given, called in /var/www/vendor/ezsql/ezsql/lib/ezQuery.php on line 633 and defined in /var/www/vendor/ezsql/ezsql/lib/Database/ez_pdo.php:173 Stack trace: #0 /var/www/vendor/ezsql/ezsql/lib/ezQuery.php(633): ezsql\Database\ez_pdo->escape(NULL) #1 /var/www/ajax.php(478): ezsql\ezQuery->update('restaurant', Array, Array) #2 {main} thrown in /var/www/vendor/ezsql/ezsql/lib/Database/ez_pdo.php on line 173`