### PR TITLE
Fix PHP 8.4 implicit nullable parameter deprecations

### DIFF
--- a/lib/Config.php
+++ b/lib/Config.php
@@ -10,7 +10,7 @@ use ezsql\ConfigInterface;
 
 class Config extends ConfigAbstract implements ConfigInterface
 {
-    public function __construct(string $driver = '', array $arguments = null)
+    public function __construct(string $driver = '', ?array $arguments = null)
     {
         $sql = \strtolower($driver);
         if (!\array_key_exists($sql, \VENDOR) || empty($arguments)) {
@@ -31,7 +31,7 @@ class Config extends ConfigAbstract implements ConfigInterface
         }
     }
 
-    public static function initialize(string $driver = '',  array $arguments = null)
+    public static function initialize(string $driver = '',  ?array $arguments = null)
     {
         return new self($driver, $arguments);
     }

--- a/lib/ConfigInterface.php
+++ b/lib/ConfigInterface.php
@@ -99,5 +99,5 @@ interface ConfigInterface
      *  for: **sqlite3** - (`filePath`, `database`)
      * - `filePath` // The path to open an SQLite database
      */
-    public static function initialize(string $driver = '', array $arguments = null);
+    public static function initialize(string $driver = '', ?array $arguments = null);
 }

--- a/lib/Database/ez_mysqli.php
+++ b/lib/Database/ez_mysqli.php
@@ -35,7 +35,7 @@ class ez_mysqli extends ezsqlModel implements DatabaseInterface
     private $database;
     protected $shortcutUsed = false;
 
-    public function __construct(ConfigInterface $settings = null)
+    public function __construct(?ConfigInterface $settings = null)
     {
         if (empty($settings)) {
             throw new Exception(\MISSING_CONFIGURATION);
@@ -278,7 +278,7 @@ class ez_mysqli extends ezsqlModel implements DatabaseInterface
      * @param array $param
      * @return bool|\mysqli_result
      */
-    public function query_prepared(string $query, array $param = null)
+    public function query_prepared(string $query, ?array $param = null)
     {
         $stmt = $this->dbh->prepare($query);
         if (!$stmt instanceof \mysqli_stmt) {

--- a/lib/Database/ez_pdo.php
+++ b/lib/Database/ez_pdo.php
@@ -35,7 +35,7 @@ class ez_pdo extends ezsqlModel implements DatabaseInterface
      */
     private $database;
 
-    public function __construct(ConfigInterface $settings = null)
+    public function __construct(?ConfigInterface $settings = null)
     {
         if (empty($settings)) {
             throw new Exception(\MISSING_CONFIGURATION);
@@ -235,7 +235,7 @@ class ez_pdo extends ezsqlModel implements DatabaseInterface
      * @param boolean $isSelect - return \PDOStatement, if SELECT SQL statement, otherwise int
      * @return bool|int|\PDOStatement
      */
-    public function query_prepared(string $query, array $param = null, $isSelect = false)
+    public function query_prepared(string $query, ?array $param = null, $isSelect = false)
     {
         $stmt = $this->dbh->prepare($query);
         $result = false;
@@ -349,7 +349,7 @@ class ez_pdo extends ezsqlModel implements DatabaseInterface
      * @param array $param
      * @return bool|void
      */
-    private function processQuery(string $query, array $param = null)
+    private function processQuery(string $query, ?array $param = null)
     {
         // Query was an insert, delete, update, replace
         if (\preg_match("/^(insert|delete|update|replace|drop|create)\s+/i", $query)) {

--- a/lib/Database/ez_pgsql.php
+++ b/lib/Database/ez_pgsql.php
@@ -35,7 +35,7 @@ class ez_pgsql extends ezsqlModel implements DatabaseInterface
      */
     private $database;
 
-    public function __construct(ConfigInterface $settings = null)
+    public function __construct(?ConfigInterface $settings = null)
     {
         if (empty($settings)) {
             throw new Exception(\MISSING_CONFIGURATION);
@@ -143,7 +143,7 @@ class ez_pgsql extends ezsqlModel implements DatabaseInterface
      * @param array $param
      * @return bool|mixed
      */
-    public function query_prepared(string $query, array $param = null)
+    public function query_prepared(string $query, ?array $param = null)
     {
         $result = @\pg_query_params($this->dbh, $query, $param);
         return ($this->shortcutUsed) ? $result : $this->processQueryResult($query, $result);

--- a/lib/Database/ez_sqlite3.php
+++ b/lib/Database/ez_sqlite3.php
@@ -39,7 +39,7 @@ class ez_sqlite3 extends ezsqlModel implements DatabaseInterface
      *  Constructor - allow the user to perform a quick connect at the
      *  same time as initializing the ez_sqlite3 class
      */
-    public function __construct(ConfigInterface $settings = null)
+    public function __construct(?ConfigInterface $settings = null)
     {
         if (empty($settings)) {
             throw new Exception(\MISSING_CONFIGURATION);
@@ -142,7 +142,7 @@ class ez_sqlite3 extends ezsqlModel implements DatabaseInterface
      * @param array $param
      * @return bool \SQLite3Result
      */
-    public function query_prepared(string $query, array $param = null)
+    public function query_prepared(string $query, ?array $param = null)
     {
         $stmt = $this->dbh->prepare($query);
         if (!$stmt instanceof \SQLite3Stmt) {

--- a/lib/Database/ez_sqlsrv.php
+++ b/lib/Database/ez_sqlsrv.php
@@ -44,7 +44,7 @@ class ez_sqlsrv extends ezsqlModel implements DatabaseInterface
      */
     private $database;
 
-    public function __construct(ConfigInterface $settings = null)
+    public function __construct(?ConfigInterface $settings = null)
     {
         if (empty($settings)) {
             throw new Exception(\MISSING_CONFIGURATION);
@@ -141,7 +141,7 @@ class ez_sqlsrv extends ezsqlModel implements DatabaseInterface
      * @param array $param
      * @return bool|mixed
      */
-    public function query_prepared(string $query, array $param = null)
+    public function query_prepared(string $query, ?array $param = null)
     {
         $result = @\sqlsrv_query($this->dbh, $query, $param);
         if ($this->shortcutUsed)

--- a/lib/DatabaseInterface.php
+++ b/lib/DatabaseInterface.php
@@ -71,7 +71,7 @@ interface DatabaseInterface
      * @param array $param
      * @return bool|mixed
      */
-    public function query_prepared(string $query, array $param = null);
+    public function query_prepared(string $query, ?array $param = null);
 
     /**
      * Perform SQL query and try to determine result value.

--- a/lib/ezFunctions.php
+++ b/lib/ezFunctions.php
@@ -68,7 +68,7 @@ if (!\function_exists('ezFunctions')) {
      * @param string $instanceTag - Store the instance for later use
      * @return \ezsql\Database\ez_pdo|\ezsql\Database\ez_pgsql|\ezsql\Database\ez_sqlsrv|\ezsql\Database\ez_sqlite3|\ezsql\Database\ez_mysqli
      */
-    function database(string $sqlDriver = null, array $connectionSetting = null, string $instanceTag = null)
+    function database(?string $sqlDriver = null, ?array $connectionSetting = null, ?string $instanceTag = null)
     {
         return Database::initialize($sqlDriver, $connectionSetting, $instanceTag);
     }
@@ -79,7 +79,7 @@ if (!\function_exists('ezFunctions')) {
      * @param string $getTag - An stored tag instance
      * @return \ezsql\Database\ez_pdo|\ezsql\Database\ez_pgsql|\ezsql\Database\ez_sqlsrv|\ezsql\Database\ez_sqlite3|\ezsql\Database\ez_mysqli
      */
-    function tagInstance(string $getTag = null)
+    function tagInstance(?string $getTag = null)
     {
         return database($getTag);
     }
@@ -93,7 +93,7 @@ if (!\function_exists('ezFunctions')) {
      *
      * @return \ezsql\Database\ez_mysqli
      */
-    function mysqlInstance(array $databaseSetting = null, string $instanceTag = null)
+    function mysqlInstance(?array $databaseSetting = null, ?string $instanceTag = null)
     {
         return database(\MYSQLI, $databaseSetting, $instanceTag);
     }
@@ -107,7 +107,7 @@ if (!\function_exists('ezFunctions')) {
      *
      * @return \ezsql\Database\ez_pgsql
      */
-    function pgsqlInstance(array $databaseSetting = null, string $instanceTag = null)
+    function pgsqlInstance(?array $databaseSetting = null, ?string $instanceTag = null)
     {
         return database(\PGSQL, $databaseSetting, $instanceTag);
     }
@@ -120,7 +120,7 @@ if (!\function_exists('ezFunctions')) {
      *
      * @return \ezsql\Database\ez_sqlsrv
      */
-    function mssqlInstance(array $databaseSetting = null, string $instanceTag = null)
+    function mssqlInstance(?array $databaseSetting = null, ?string $instanceTag = null)
     {
         return database(\MSSQL, $databaseSetting, $instanceTag);
     }
@@ -133,7 +133,7 @@ if (!\function_exists('ezFunctions')) {
      *
      * @return \ezsql\Database\ez_pdo
      */
-    function pdoInstance(array $databaseSetting = null, string $instanceTag = null)
+    function pdoInstance(?array $databaseSetting = null, ?string $instanceTag = null)
     {
         return database(\Pdo, $databaseSetting, $instanceTag);
     }
@@ -146,7 +146,7 @@ if (!\function_exists('ezFunctions')) {
      *
      * @return \ezsql\Database\ez_sqlite3
      */
-    function sqliteInstance(array $databaseSetting = null, string $instanceTag = null)
+    function sqliteInstance(?array $databaseSetting = null, ?string $instanceTag = null)
     {
         return database(\SQLITE3, $databaseSetting, $instanceTag);
     }
@@ -157,7 +157,7 @@ if (!\function_exists('ezFunctions')) {
      *
      * @return string|null `mysqli`|`pgsql`|`sqlite3`|`sqlsrv`
      */
-    function get_vendor(DatabaseInterface $instance = null): ?string
+    function get_vendor(?DatabaseInterface $instance = null): ?string
     {
         return ezSchema::vendor($instance);
     }
@@ -191,7 +191,7 @@ if (!\function_exists('ezFunctions')) {
      *
      * @return string|bool - SQL schema string, or false for error
      */
-    function column(string $column = null, string $type = null, ...$arguments)
+    function column(?string $column = null, ?string $type = null, ...$arguments)
     {
         return ezSchema::column($column, $type, ...$arguments);
     }
@@ -625,7 +625,7 @@ if (!\function_exists('ezFunctions')) {
         string $certificateFile = 'certificate.crt',
         string $signingFile = 'certificate.csr',
         // string $caCertificate = null,
-        string $ssl_path = null,
+        ?string $ssl_path = null,
         array $details = ["commonName" => "localhost"]
     ) {
         if (empty($ssl_path)) {
@@ -966,7 +966,7 @@ if (!\function_exists('ezFunctions')) {
      * @return mixed bool/result - false for error
      * @codeCoverageIgnore
      */
-    function select_into(string $newTable, $fromColumns = '*', string $oldTable = null, ...$fromWhereConditions)
+    function select_into(string $newTable, $fromColumns = '*', ?string $oldTable = null, ...$fromWhereConditions)
     {
         $ezQuery = getInstance();
         return ($ezQuery instanceof DatabaseInterface)

--- a/lib/ezQuery.php
+++ b/lib/ezQuery.php
@@ -129,11 +129,11 @@ class ezQuery implements ezQueryInterface
     }
 
     public function innerJoin(
-        string $leftTable = null,
-        string $rightTable = null,
-        string $leftColumn = null,
-        string $rightColumn = null,
-        string $tableAs = null,
+        ?string $leftTable = null,
+        ?string $rightTable = null,
+        ?string $leftColumn = null,
+        ?string $rightColumn = null,
+        ?string $tableAs = null,
         $condition = \EQ
     ) {
         return $this->joining(
@@ -148,11 +148,11 @@ class ezQuery implements ezQueryInterface
     }
 
     public function leftJoin(
-        string $leftTable = null,
-        string $rightTable = null,
-        string $leftColumn = null,
-        string $rightColumn = null,
-        string $tableAs = null,
+        ?string $leftTable = null,
+        ?string $rightTable = null,
+        ?string $leftColumn = null,
+        ?string $rightColumn = null,
+        ?string $tableAs = null,
         $condition = \EQ
     ) {
         return $this->joining(
@@ -167,11 +167,11 @@ class ezQuery implements ezQueryInterface
     }
 
     public function rightJoin(
-        string $leftTable = null,
-        string $rightTable = null,
-        string $leftColumn = null,
-        string $rightColumn = null,
-        string $tableAs = null,
+        ?string $leftTable = null,
+        ?string $rightTable = null,
+        ?string $leftColumn = null,
+        ?string $rightColumn = null,
+        ?string $tableAs = null,
         $condition = \EQ
     ) {
         return $this->joining(
@@ -186,11 +186,11 @@ class ezQuery implements ezQueryInterface
     }
 
     public function fullJoin(
-        string $leftTable = null,
-        string $rightTable = null,
-        string $leftColumn = null,
-        string $rightColumn = null,
-        string $tableAs = null,
+        ?string $leftTable = null,
+        ?string $rightTable = null,
+        ?string $leftColumn = null,
+        ?string $rightColumn = null,
+        ?string $tableAs = null,
         $condition = \EQ
     ) {
         return $this->joining(
@@ -232,11 +232,11 @@ class ezQuery implements ezQueryInterface
      */
     private function joining(
         String $type = \_INNER,
-        string $leftTable = null,
-        string $rightTable = null,
-        string $leftColumn = null,
-        string $rightColumn = null,
-        string $tableAs = null,
+        ?string $leftTable = null,
+        ?string $rightTable = null,
+        ?string $leftColumn = null,
+        ?string $rightColumn = null,
+        ?string $tableAs = null,
         $condition = \EQ
     ) {
         if (
@@ -467,7 +467,7 @@ class ezQuery implements ezQueryInterface
         return ($where != '1') ? " $whereOrHaving $where " : ' ';
     }
 
-    public function select(string $table = null, $columnFields = '*', ...$conditions)
+    public function select(?string $table = null, $columnFields = '*', ...$conditions)
     {
         $getFromTable = $this->fromTable;
         $getSelect_result = $this->select_result;
@@ -566,12 +566,12 @@ class ezQuery implements ezQueryInterface
         return $this->select($table, $columnFields, ...$conditions);
     }
 
-    public function union(string $table = null, $columnFields = '*', ...$conditions)
+    public function union(?string $table = null, $columnFields = '*', ...$conditions)
     {
         return 'UNION ' . $this->select_sql($table, $columnFields, ...$conditions);
     }
 
-    public function unionAll(string $table = null, $columnFields = '*', ...$conditions)
+    public function unionAll(?string $table = null, $columnFields = '*', ...$conditions)
     {
         return 'UNION ALL ' . $this->select_sql($table, $columnFields, ...$conditions);
     }
@@ -596,7 +596,7 @@ class ezQuery implements ezQueryInterface
     /**
      * @codeCoverageIgnore
      */
-    public function select_into(string $newTable, $fromColumns = '*', string $oldTable = null, ...$fromWhereConditions)
+    public function select_into(string $newTable, $fromColumns = '*', ?string $oldTable = null, ...$fromWhereConditions)
     {
         $this->isInto = true;
         if (isset($oldTable))
@@ -613,7 +613,7 @@ class ezQuery implements ezQueryInterface
         return $this->clearPrepare();
     }
 
-    public function update(string $table = null, $keyValue, ...$whereConditions)
+    public function update(?string $table = null, $keyValue, ...$whereConditions)
     {
         if (!\is_array($keyValue) || empty($table)) {
             return $this->clearPrepare();
@@ -646,7 +646,7 @@ class ezQuery implements ezQueryInterface
         return $this->clearPrepare();
     }
 
-    public function delete(string $table = null, ...$whereConditions)
+    public function delete(?string $table = null, ...$whereConditions)
     {
         if (empty($table)) {
             return $this->clearPrepare();
@@ -726,17 +726,17 @@ class ezQuery implements ezQueryInterface
         }
     }
 
-    public function replace(string $table = null, $keyValue)
+    public function replace(?string $table = null, $keyValue)
     {
         return $this->_query_insert_replace($table, $keyValue, 'REPLACE');
     }
 
-    public function insert(string $table = null, $keyValue)
+    public function insert(?string $table = null, $keyValue)
     {
         return $this->_query_insert_replace($table, $keyValue, 'INSERT');
     }
 
-    public function insert_select(string $toTable = null, $toColumns = '*', $fromTable = null, $fromColumns = '*', ...$conditions)
+    public function insert_select(?string $toTable = null, $toColumns = '*', $fromTable = null, $fromColumns = '*', ...$conditions)
     {
         $putToTable = $this->_query_insert_replace($toTable, $toColumns, 'INSERT', false);
         $getFromTable = $this->select_sql($fromTable, $fromColumns, ...$conditions);
@@ -750,7 +750,7 @@ class ezQuery implements ezQueryInterface
     }
 
     // get_results call template
-    public function get_results(string $query = null, $output = \OBJECT, bool $use_prepare = false)
+    public function get_results(?string $query = null, $output = \OBJECT, bool $use_prepare = false)
     {
         return array();
     }
@@ -821,7 +821,7 @@ class ezQuery implements ezQueryInterface
         return false;
     }
 
-    public function create(string $table = null, ...$schemas)
+    public function create(?string $table = null, ...$schemas)
     {
         $vendor = get_vendor();
         if (empty($table) || empty($schemas) || empty($vendor))
@@ -884,7 +884,7 @@ class ezQuery implements ezQueryInterface
         return false;
     }
 
-    public function alter(string $table = null, ...$alteringSchema)
+    public function alter(?string $table = null, ...$alteringSchema)
     {
         if (empty($table) || empty($alteringSchema))
             return false;
@@ -915,7 +915,7 @@ class ezQuery implements ezQueryInterface
         return false;
     }
 
-    public function drop(string $table = null)
+    public function drop(?string $table = null)
     {
         if (empty($table))
             return false;

--- a/lib/ezQueryInterface.php
+++ b/lib/ezQueryInterface.php
@@ -114,11 +114,11 @@ interface ezQueryInterface
      * @return bool|string JOIN sql statement, false for error
      */
     public function innerJoin(
-        string $leftTable = null,
-        string $rightTable = null,
-        string $leftColumn = null,
-        string $rightColumn = null,
-        string $tableAs = null,
+        ?string $leftTable = null,
+        ?string $rightTable = null,
+        ?string $leftColumn = null,
+        ?string $rightColumn = null,
+        ?string $tableAs = null,
         $condition = \EQ
     );
 
@@ -148,11 +148,11 @@ interface ezQueryInterface
      * @return bool|string JOIN sql statement, false for error
      */
     public function leftJoin(
-        string $leftTable = null,
-        string $rightTable = null,
-        string $leftColumn = null,
-        string $rightColumn = null,
-        string $tableAs = null,
+        ?string $leftTable = null,
+        ?string $rightTable = null,
+        ?string $leftColumn = null,
+        ?string $rightColumn = null,
+        ?string $tableAs = null,
         $condition = \EQ
     );
 
@@ -182,11 +182,11 @@ interface ezQueryInterface
      * @return bool|string JOIN sql statement, false for error
      */
     public function rightJoin(
-        string $leftTable = null,
-        string $rightTable = null,
-        string $leftColumn = null,
-        string $rightColumn = null,
-        string $tableAs = null,
+        ?string $leftTable = null,
+        ?string $rightTable = null,
+        ?string $leftColumn = null,
+        ?string $rightColumn = null,
+        ?string $tableAs = null,
         $condition = \EQ
     );
 
@@ -215,11 +215,11 @@ interface ezQueryInterface
      * @return bool|string JOIN sql statement, false for error
      */
     public function fullJoin(
-        string $leftTable = null,
-        string $rightTable = null,
-        string $leftColumn = null,
-        string $rightColumn = null,
-        string $tableAs = null,
+        ?string $leftTable = null,
+        ?string $rightTable = null,
+        ?string $leftColumn = null,
+        ?string $rightColumn = null,
+        ?string $tableAs = null,
         $condition = \EQ
     );
 
@@ -246,7 +246,7 @@ interface ezQueryInterface
      *
      * @return bool|string - false for error
      */
-    public function union(string $table = null, $columnFields = '*', ...$conditions);
+    public function union(?string $table = null, $columnFields = '*', ...$conditions);
 
     /**
      * Returns an `UNION ALL` SELECT SQL string, given the
@@ -271,7 +271,7 @@ interface ezQueryInterface
      *
      * @return bool|string - false for error
      */
-    public function unionAll(string $table = null, $columnFields = '*', ...$conditions);
+    public function unionAll(?string $table = null, $columnFields = '*', ...$conditions);
 
     /**
      * Specifies an ordering for the query results.
@@ -387,7 +387,7 @@ interface ezQueryInterface
      *
      * @return mixed|object result set - see docs for more details, or false for error
      */
-    public function select(string $table = null, $columnFields = '*', ...$conditions);
+    public function select(?string $table = null, $columnFields = '*', ...$conditions);
 
     /**
      * Preforms a `select` method call on a already preset `table name`, and optional `prefix`
@@ -435,7 +435,7 @@ interface ezQueryInterface
      * @param $keyValue - table fields, assoc array with key = value (doesn't need escaped)
      * @return mixed bool/id of inserted record, or false for error
      */
-    public function insert(string $table = null, $keyValue);
+    public function insert(?string $table = null, $keyValue);
 
     /**
      * Preforms a `insert` method call on a already preset `table name`, and optional `prefix`
@@ -504,7 +504,7 @@ interface ezQueryInterface
      *```
      * @return mixed bool/result - false for error
      */
-    public function select_into(string $newTable, $fromColumns = '*', string $oldTable = null, ...$fromWhereConditions);
+    public function select_into(string $newTable, $fromColumns = '*', ?string $oldTable = null, ...$fromWhereConditions);
 
     /**
      * Does an `update` query with an array, by conditional operator array
@@ -531,7 +531,7 @@ interface ezQueryInterface
      *```
      * @return mixed bool/results - false for error
      */
-    public function update(string $table = null, $keyValue, ...$whereConditions);
+    public function update(?string $table = null, $keyValue, ...$whereConditions);
 
     /**
      * Preforms a `update` method call on a already preset `table name`, and optional `prefix`
@@ -588,7 +588,7 @@ interface ezQueryInterface
      *```
      * @return mixed bool/results - false for error
      */
-    public function delete(string $table = null, ...$whereConditions);
+    public function delete(?string $table = null, ...$whereConditions);
 
     /**
      * Preforms a `delete` method call on a already preset `table name`, and optional `prefix`
@@ -626,7 +626,7 @@ interface ezQueryInterface
      * @param $keyValue - table fields, assoc array with key = value (doesn't need escaped)
      * @return mixed bool/id of replaced record, or false for error
      */
-    public function replace(string $table = null, $keyValue);
+    public function replace(?string $table = null, $keyValue);
 
     /**
      * Preforms a `replace` method call on a already preset `table name`, and optional `prefix`
@@ -668,7 +668,7 @@ interface ezQueryInterface
      * @return mixed bool/id of inserted record, or false for error
      */
     public function insert_select(
-        string $toTable = null,
+        ?string $toTable = null,
         $toColumns = '*',
         $fromTable = null,
         $fromColumns = '*',
@@ -695,7 +695,7 @@ interface ezQueryInterface
      *
      * @return mixed results of query() call
      */
-    public function create(string $table = null, ...$schemas);
+    public function create(?string $table = null, ...$schemas);
 
     /**
      * Preforms a `create` method call on a already preset `table name`, and optional `prefix`
@@ -729,7 +729,7 @@ interface ezQueryInterface
      *
      * @return bool|int
      */
-    public function drop(string $table = null);
+    public function drop(?string $table = null);
 
     /**
      * Preforms a `drop` method call on a already preset `table name`, and optional `prefix`
@@ -761,7 +761,7 @@ interface ezQueryInterface
      *
      * @return mixed results of query() call
      */
-    public function alter(string $table = null, ...$alteringSchema);
+    public function alter(?string $table = null, ...$alteringSchema);
 
     /**
      * Preforms a `alter` method call on a already preset `table name`, and optional `prefix`

--- a/lib/ezSchema.php
+++ b/lib/ezSchema.php
@@ -163,7 +163,7 @@ class ezSchema
      *
      * @return string|null `mysqli`|`pgsql`|`sqlite3`|`sqlsrv`
      */
-    public static function vendor(DatabaseInterface $db = null)
+    public static function vendor(?DatabaseInterface $db = null)
     {
         $type = null;
         $instance = empty($db) || !is_object($db) ? getInstance() : $db;
@@ -202,7 +202,7 @@ class ezSchema
      *
      * @return string|bool - SQL schema string, or false for error
      */
-    public static function column(string $column = null, string $type = null, ...$args)
+    public static function column(?string $column = null, ?string $type = null, ...$args)
     {
         $vendor = self::vendor();
         if (empty($column) || empty($type) || empty($vendor))

--- a/lib/ezsqlModel.php
+++ b/lib/ezsqlModel.php
@@ -489,7 +489,7 @@ class ezsqlModel extends ezQuery implements ezsqlModelInterface
 		\array_push($this->allFuncCalls, $this->funcCall);
 	}
 
-	public function get_var(string $query = null, int $x = 0, int $y = 0, bool $use_prepare = false)
+	public function get_var(?string $query = null, int $x = 0, int $y = 0, bool $use_prepare = false)
 	{
 		// Log how the function was called
 		$this->log_query("\$db->get_var(\"$query\",$x,$y)");
@@ -508,7 +508,7 @@ class ezsqlModel extends ezQuery implements ezsqlModelInterface
 		return (isset($values[$x]) && $values[$x] !== null) ? $values[$x] : null;
 	}
 
-	public function get_row(string $query = null, $output = \OBJECT, int $y = 0, bool $use_prepare = false)
+	public function get_row(?string $query = null, $output = \OBJECT, int $y = 0, bool $use_prepare = false)
 	{
 		// Log how the function was called
 		$this->log_query("\$db->get_row(\"$query\",$output,$y)");
@@ -533,7 +533,7 @@ class ezsqlModel extends ezQuery implements ezsqlModelInterface
 		}
 	}
 
-	public function get_col(string $query = null, int $x = 0, bool $use_prepare = false)
+	public function get_col(?string $query = null, int $x = 0, bool $use_prepare = false)
 	{
 		$new_array = array();
 
@@ -553,7 +553,7 @@ class ezsqlModel extends ezQuery implements ezsqlModelInterface
 		return $new_array;
 	}
 
-	public function get_results(string $query = null, $output = \OBJECT, bool $use_prepare = false)
+	public function get_results(?string $query = null, $output = \OBJECT, bool $use_prepare = false)
 	{
 		// Log how the function was called
 		$this->log_query("\$db->get_results(\"$query\", $output, $use_prepare)");
@@ -601,7 +601,7 @@ class ezsqlModel extends ezQuery implements ezsqlModelInterface
 		}
 	}
 
-	public function create_cache(string $path = null)
+	public function create_cache(?string $path = null)
 	{
 		$cache_dir = empty($path) ? $this->cacheDir : $path;
 		if (!\is_dir($cache_dir)) {

--- a/lib/ezsqlModelInterface.php
+++ b/lib/ezsqlModelInterface.php
@@ -267,7 +267,7 @@ interface ezsqlModelInterface
 	 * @param int $y - row offset
 	 * @return bool|mixed
 	 */
-	public function get_var(string $query = null, int $x = 0, int $y = 0, bool $use_prepare = false);
+	public function get_var(?string $query = null, int $x = 0, int $y = 0, bool $use_prepare = false);
 
 	/**
 	 * Get one row from the database (or previously cached results)
@@ -283,7 +283,7 @@ interface ezsqlModelInterface
 	 * @param int $y - row offset
 	 * @return bool|mixed
 	 */
-	public function get_row(string $query = null, $output = \OBJECT, int $y = 0, bool $use_prepare = false);
+	public function get_row(?string $query = null, $output = \OBJECT, int $y = 0, bool $use_prepare = false);
 
 	/**
 	 * Get one column from query (or previously cached results) based on column offset
@@ -298,7 +298,7 @@ interface ezsqlModelInterface
 	 * @param bool $use_prepare - has prepare statements been activated
 	 * @return bool|mixed
 	 */
-	public function get_col(string $query = null, int $x = 0, bool $use_prepare = false);
+	public function get_col(?string $query = null, int $x = 0, bool $use_prepare = false);
 
 	/**
 	 * Get multiple row result set from the database
@@ -333,7 +333,7 @@ interface ezsqlModelInterface
 	 * @param bool $use_prepare - has prepare statements been activated
 	 * @return bool|object|array - results as objects (default)
 	 */
-	public function get_results(string $query = null, $output = \OBJECT, bool $use_prepare = false);
+	public function get_results(?string $query = null, $output = \OBJECT, bool $use_prepare = false);
 
 	/**
 	 * Get information about one or all columns such as column name or type.
@@ -379,7 +379,7 @@ interface ezsqlModelInterface
 	 *
 	 * @param string $path
 	 */
-	public function create_cache(string $path = null);
+	public function create_cache(?string $path = null);
 
 	/**
 	 * Store cache


### PR DESCRIPTION
## Summary

PHP 8.4 deprecated implicitly nullable parameters — typed parameters with a `null` default value that don't use the explicit `?Type` notation. This triggers hundreds of `E_DEPRECATED` warnings on every request.

This PR updates all affected function signatures across the library from:
```php
function foo(Type $param = null)
```
to:
```php
function foo(?Type $param = null)
```

### Files changed (14)

- `lib/Config.php`
- `lib/ConfigInterface.php`
- `lib/DatabaseInterface.php`
- `lib/Database/ez_mysqli.php`
- `lib/Database/ez_pdo.php`
- `lib/Database/ez_pgsql.php`
- `lib/Database/ez_sqlite3.php`
- `lib/Database/ez_sqlsrv.php`
- `lib/ezFunctions.php`
- `lib/ezQuery.php`
- `lib/ezQueryInterface.php`
- `lib/ezSchema.php`
- `lib/ezsqlModel.php`
- `lib/ezsqlModelInterface.php`

### Testing

- Ran the existing test suite (`phpunit`) — results are identical before and after this change (same pass/fail/skip counts)
- All 22 PHP files pass `php -l` syntax validation
- No behavioral changes — this is purely a type annotation fix

Fixes #226