### PR TITLE
Fix PHP 8.4 pg_escape_string() deprecation in ez_pgsql

### DIFF
--- a/lib/Database/ez_pgsql.php
+++ b/lib/Database/ez_pgsql.php
@@ -122,7 +122,7 @@ class ez_pgsql extends ezsqlModel implements DatabaseInterface
      */
     public function escape(string $str)
     {
-        return \pg_escape_string(\stripslashes($str));
+        return \pg_escape_string($this->dbh, \stripslashes($str));
     } // escape
 
     /**


### PR DESCRIPTION
## Summary

PHP 8.4 deprecated calling `pg_escape_string()` without explicitly passing the connection resource as the first argument:

```
pg_escape_string(): Automatic fetching of PostgreSQL connection is deprecated
```

This updates `ez_pgsql::escape()` to pass `$this->dbh` as the first argument, consistent with how `ez_mysqli::escape()` already passes its connection handle to `mysqli_real_escape_string()`.

### Change

```php
// Before
return \pg_escape_string(\stripslashes($str));

// After
return \pg_escape_string($this->dbh, \stripslashes($str));
```

### Testing

- Full test suite results are identical before and after this change
- Syntax validated with `php -l`
- Single line change, no behavioral impact

See #226