### PR TITLE
Handle empty parameters in prepared statement execution

### DIFF
--- a/lib/Database/ez_mysqli.php
+++ b/lib/Database/ez_mysqli.php
@@ -288,6 +288,15 @@ class ez_mysqli extends ezsqlModel implements DatabaseInterface
             return false;
         }
 
+        if (empty($param)) {
+            $result = ($stmt->execute()) ? $this->fetch_prepared_result($stmt, $query) : false;
+
+            $stmt->free_result();
+            $stmt->close();
+
+            return $result;
+        }
+
         $params = [];
         $types = \array_reduce(
             $param,


### PR DESCRIPTION
Add check for empty parameters before executing statement. query_prepared() now safely executes queries with no bound params instead of crashing on empty bind_param() types