### PR TITLE
docs: fix typo (postgress->postgres (x1))

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,7 +139,7 @@ News about ezSQL3 are available at http://stefanie-stoelting.de/ezsql3-news.html
 
         Update (Postgress SQL Version)
 
-         - Our old friend Tom De Bruyne as updated the postgress
+         - Our old friend Tom De Bruyne as updated the postgres
            version.
 
            1) It now works without throwing errors (also thanks Geert Nijpels)

--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ For the functions **usage/docs** see [ezFunctions.php](https://github.com/ezSQL/
 
 ## Contributing
 
-Contributions are encouraged and welcome; I am always happy to get feedback or pull requests on Github :) Create [Github Issues](https://github.com/ezSQL/ezsql/issues) for bugs and new features and comment on the ones you are interested in.
+Contributions are encouraged and welcome; I am always happy to get feedback or pull requests on GitHub :) Create [GitHub Issues](https://github.com/ezSQL/ezsql/issues) for bugs and new features and comment on the ones you are interested in.
 
 ## License
 

--- a/WIKI.md
+++ b/WIKI.md
@@ -618,7 +618,7 @@ $db->get_col – get one column from query (or previously cached results) based 
 
 **$db->get_col**( string query / null [, int column offset] )
 
-**$db->get_col**() extracts one column as one dimensional array based on a column offset. If no offset is supplied the offset will defualt to column 0. I.E the first column. If a null query is supplied the previous query results are used.
+**$db->get_col**() extracts one column as one dimensional array based on a column offset. If no offset is supplied the offset will default to column 0. I.E the first column. If a null query is supplied the previous query results are used.
 
 Example 1
 


### PR DESCRIPTION
## Summary
Fixes spelling/typo issues found in this project's documentation.

**Details:** Fix documentation typos: postgress->postgres (x1); defualt->default (x1); Github->GitHub (x2)

**Files:**
- `CHANGELOG.md`
- `WIKI.md`
- `README.md`

Documentation-only; no functional code changes.
